### PR TITLE
chore: move to npm registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20.x'
-          registry-url: 'https://npm.pkg.github.com'
+          registry-url: https://registry.npmjs.org
           scope: '@subifinancial'
 
       - name: 🧩 Install Dependencies
@@ -49,5 +49,5 @@ jobs:
           publish: npm run cs:publish
           commit: 'chore(release): version package 🔗🦋'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
### TL;DR

Changed the node registry URL from GitHub to npm and updated authentication tokens in the release workflow configuration.

### What changed?

- Updated the registry-url from `https://npm.pkg.github.com` to `https://registry.npmjs.org` in the `actions/setup-node` step.
- Changed `GITHUB_TOKEN` to `NPM_TOKEN` and `NODE_AUTH_TOKEN` to use secrets `NPM_AUTH_TOKEN` instead of `GITHUB_TOKEN`.

### How to test?

1. Trigger a workflow dispatch for the release workflow.
2. Ensure the dependencies are installed correctly from npm registry.
3. Verify that the package is published successfully using the new `NPM_TOKEN`.

### Why make this change?

The change aims to switch to npm registry for easier distribution.