### PR TITLE
fix: add GITHUB_TOKEN to changesets action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,5 +49,6 @@ jobs:
           publish: npm run cs:publish
           commit: 'chore(release): version package 🔗🦋'
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
### TL;DR
Added the missing `GITHUB_TOKEN` to the release workflow to ensure successful authentication during the deployment process.