### PR TITLE
fix: add auto release on merge from changeset-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
         description: 'Do you want to create a release PR?'
         default: false
         required: true
+  push:
+    branches:
+      - main
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -16,6 +19,10 @@ jobs:
   release:
     name: 🚀 Release
     runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'workflow_dispatch' || (github.event_name == 'push'
+      && github.event.ref == 'refs/heads/main' &&  github.event.before ==
+      'refs/heads/changeset-release/main')
 
     steps:
       - name: ⬇️ Checkout


### PR DESCRIPTION
### TL;DR
Add push trigger to release workflow for main branch.

### What changed?
- Added push trigger for the main branch in the release workflow.
- Updated the concurrency key in the workflow.
- Added conditional step to run the release job if the push event is on 'refs/heads/main' and the previous reference is 'refs/heads/changeset-release/main'.