### PR TITLE
fix: release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
         description: 'Do you want to create a release PR?'
         default: false
         required: true
-  push:
+  pull_request:
     branches:
       - main
 
@@ -20,9 +20,10 @@ jobs:
     name: 🚀 Release
     runs-on: ubuntu-latest
     if: >
-      github.event_name == 'workflow_dispatch' || (github.event_name == 'push'
-      && github.event.ref == 'refs/heads/main' &&  github.event.before ==
-      'refs/heads/changeset-release/main')
+      github.event_name == 'workflow_dispatch' || (github.event_name ==
+      'pull_request' && github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.head.ref == 'changeset-release/main')
 
     steps:
       - name: ⬇️ Checkout


### PR DESCRIPTION
### TL;DR

This PR changes the GitHub Actions workflow to automatically trigger a release when changes are merged from the `changeset-release/main` branch into `main`.

### What changed?

- The GitHub Actions workflow file `.github/workflows/release.yml` has been updated.
- The `push` trigger has been replaced with a `pull_request` trigger for the `main` branch.
- The release job now checks if the PR is merged into `main` from `changeset-release/main`.

### How to test?

1. Create a pull request from the `changeset-release/main` branch to the `main` branch.
2. Merge the pull request.
3. Verify that the release job is triggered.

### Why make this change?

This change ensures that releases are automatically triggered when changes from the `changeset-release/main` branch are merged into the `main` branch, streamlining the release process.