### PR TITLE
chore: add cs for previous pr

### DIFF
--- a/.changeset/clever-houses-call.md
+++ b/.changeset/clever-houses-call.md
@@ -1,0 +1,6 @@
+---
+'@subifinancial/subi-connect': patch
+---
+
+Added `hasConnection` field to the useCompany to determine if the company has
+integrated with a payroll yet.


### PR DESCRIPTION
Added `hasConnection` field to the useCompany to determine if the company has integrated with a payroll yet. This PR adds the Changeset.