### PR TITLE
fix: github workflow on cs merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,8 @@ on:
         default: false
         required: true
   pull_request:
-    branches:
-      - main
+    types:
+      - closed
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
### TL;DR

Updated the GitHub Actions release workflow to trigger on merged cs pull requests.

### What changed?

- Modified `.github/workflows/release.yml` to change the trigger event to `pull_request` with a type of `closed` rather than to specific branches.