### PR TITLE
fix: load normal envs during build

### DIFF
--- a/.changeset/fluffy-papayas-build.md
+++ b/.changeset/fluffy-papayas-build.md
@@ -1,0 +1,5 @@
+---
+'@subifinancial/subi-connect': patch
+---
+
+Fix image url during build time

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,11 +42,6 @@ jobs:
       - name: 🧩 Install Dependencies
         run: npm ci
 
-      - name: 🔏 'Create env file'
-        run: |
-          touch .env.production
-          echo SUBI_CONNECT_PUBLIC_BASE_URL=${{ secrets.SUBI_CONNECT_PUBLIC_BASE_URL }} >> .env.production
-
       - name: 🏗️ Build
         run: npm run build:prod
 

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -11,6 +11,9 @@ import { dts } from 'rollup-plugin-dts';
 import peerDepsExternal from 'rollup-plugin-peer-deps-external';
 import postcss from 'rollup-plugin-postcss';
 
+// Load .env
+dotenv.config();
+// Override any other environment variables with environment specific .env
 dotenv.config({path: process.env.NODE_ENV ? `.env.${process.env.NODE_ENV}` : '.env.production'});
 
 import packageJson from "./package.json" assert { type: 'json' };


### PR DESCRIPTION
### TL;DR

Removed the creation of the `.env.production` file from the GitHub Actions release workflow, and updated the Rollup configuration to use environment-specific `.env` files based on the `NODE_ENV` variable.

### What changed?

- Removed the creation of `.env.production` file in `.github/workflows/release.yml`.
- Updated `rollup.config.mjs` to load environment-specific `.env` files based on `NODE_ENV`.

### How to test?

1. Trigger the GitHub Actions release workflow and ensure it skips the creation of `.env.production` file.
2. Verify that the build process works correctly and environment variables are loaded based on the `NODE_ENV` setting.