### PR TITLE
fix: add envs to release build

### DIFF
--- a/.changeset/fuzzy-flies-raise.md
+++ b/.changeset/fuzzy-flies-raise.md
@@ -1,0 +1,5 @@
+---
+'@subifinancial/subi-connect': patch
+---
+
+Add correct URL envs to the release build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,11 @@ jobs:
 
       - name: 🏗️ Build
         run: npm run build:prod
+        env:
+          SUBI_CONNECT_IMAGES_BASE_URL:
+            ${{ secrets.SUBI_CONNECT_IMAGES_BASE_URL }}
+          SUBI_CONNECT_PUBLIC_BASE_URL:
+            ${{ secrets.SUBI_CONNECT_PUBLIC_BASE_URL }}
 
       - name: 📣 Create Release Pull Request or Publish to npm
         uses: changesets/action@v1


### PR DESCRIPTION
### TL;DR

Add correct URL envs to the release build in the GitHub Actions workflow.

### What changed?

- Added environment variables `SUBI_CONNECT_IMAGES_BASE_URL` and `SUBI_CONNECT_PUBLIC_BASE_URL` to the build step in `.github/workflows/release.yml`.
- Created a changeset file `.changeset/fuzzy-flies-raise.md` marking the change as a patch for `@subifinancial/subi-connect`.

### How to test?

Verify that the release build in the GitHub Actions workflow uses the correct URL environment variables.