### PR TITLE
fix: change publishConfig to npm registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "react-dom": ">=18"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/subifinancial"
+    "registry": "https://registry.npmjs.org/"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### TL;DR
The registry URL in the publishConfig section of package.json has been updated from GitHub's npm registry to the official npm registry.

### What changed?
- Updated the registry URL in `package.json` from `https://npm.pkg.github.com/subifinancial` to `https://registry.npmjs.org/`.

### How to test?
1. Verify the `registry` field under `publishConfig` in `package.json` is now `https://registry.npmjs.org/`.
2. Ensure package publishing points to the official npm registry.

### Why make this change?
This change standardizes the package publishing process by using the official npm registry, facilitating easier access and distribution of the package.