### PR TITLE
refactor: change NODE_ENV to TARGET_ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,5 +104,5 @@ generated access token.
 2. `npm run build-storybook`
 3. `npm run storybook`
 
-- Ensure you select your `NODE_ENV` with `NODE_ENV=local npm run ...`
+- Ensure you select your `TARGET_ENV` with `TARGET_ENV=local npm run ...`
 - View the README docs in `/demo` for more information

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -14,7 +14,7 @@ import postcss from 'rollup-plugin-postcss';
 // Load .env
 dotenv.config();
 // Override any other environment variables with environment specific .env
-dotenv.config({path: process.env.NODE_ENV ? `.env.${process.env.NODE_ENV}` : '.env.production'});
+dotenv.config({path: process.env.TARGET_ENV ? `.env.${process.env.TARGET_ENV}` : '.env.production'});
 
 import packageJson from "./package.json" assert { type: 'json' };
 
@@ -43,6 +43,9 @@ export default [
       replace({
         'process.env.NODE_ENV': JSON.stringify(
           process.env.NODE_ENV ?? 'production',
+        ),
+        'process.env.TARGET_ENV': JSON.stringify(
+          process.env.TARGET_ENV ?? 'production',
         ),
         'process.env.SUBI_CONNECT_PUBLIC_BASE_URL': JSON.stringify(
           process.env.SUBI_CONNECT_PUBLIC_BASE_URL,

--- a/scripts/pack.sh
+++ b/scripts/pack.sh
@@ -74,12 +74,12 @@ print_env() {
 
 process_env() {
     local ENV=$1
-    NODE_ENV=$ENV 
+    TARGET_ENV=$ENV 
 
     print_env $ENV
 
     echo "Building..."
-    NODE_ENV=$ENV npm run build
+    NODE_ENV=production npm run build
 
     # Remove existing tarballs matching the pattern
     # Remove existing tarballs matching the pattern unless --no-delete is active

--- a/src/services/logger/local-logger.ts
+++ b/src/services/logger/local-logger.ts
@@ -7,7 +7,7 @@ class LocalLogger implements ILogger {
   ): Promise<void> {
     const logMessage = `%c [🔗] ${key} `;
 
-    if (process.env.NODE_ENV === 'local') {
+    if (process.env.TARGET_ENV === 'local') {
       console.log(
         ...[
           logMessage,
@@ -25,7 +25,7 @@ class LocalLogger implements ILogger {
   ): Promise<void> {
     const logMessage = `%c [🔗] ${key} [${error.message}] `;
 
-    if (process.env.NODE_ENV === 'local') {
+    if (process.env.TARGET_ENV === 'local') {
       console.error(
         ...[
           logMessage,

--- a/src/types/main.ts
+++ b/src/types/main.ts
@@ -11,7 +11,7 @@ export type SubiConnectOptions = {
     baseURL?: string;
 
     /**
-     * Disables logging to the console when NODE_ENV = local.
+     * Disables logging to the console when TARGET_ENV = local.
      */
     disabledLogging?: boolean;
   };


### PR DESCRIPTION
### TL;DR

Updated various scripts and configurations to use `TARGET_ENV` instead of `NODE_ENV` for the environment variable.

### What changed?

1. Updated `README.md` to reflect the change from `NODE_ENV` to `TARGET_ENV`.
2. Modified `rollup.config.mjs` to load `.env` based on `TARGET_ENV` instead of `NODE_ENV`.
3. Adjusted `scripts/pack.sh` to utilize `TARGET_ENV`.
4. Updated `local-logger.ts` to check `TARGET_ENV` for logging decisions.
5. Changed comments and types in `main.ts` documentation from `NODE_ENV` to `TARGET_ENV`.

### How to test?

1. Run `npm run build-storybook` and `npm run storybook` to ensure functioning as expected.
2. Verify that the appropriate `.env` files are being loaded based on `TARGET_ENV`.
3. Run the modified `pack.sh` script and ensure assets are built correctly.
4. Check logging behavior in local development.

### Why make this change?

To distinguish clearly between different target environments without overloading `NODE_ENV`, thereby making the configuration more intuitive and maintainable.