### PR TITLE
Expose all Subi Connect types

### DIFF
--- a/.changeset/clean-badgers-heal.md
+++ b/.changeset/clean-badgers-heal.md
@@ -1,0 +1,5 @@
+---
+'@subifinancial/subi-connect': minor
+---
+
+Expose all Subi Connect types

--- a/demo/world-pay/package-lock.json
+++ b/demo/world-pay/package-lock.json
@@ -9,7 +9,7 @@
         "@radix-ui/react-label": "^2.0.2",
         "@radix-ui/react-slot": "^1.0.2",
         "@radix-ui/react-switch": "^1.0.3",
-        "@subifinancial/subi-connect": "file:../lib/subi-connect@local-9ed5a.tgz",
+        "@subifinancial/subi-connect": "file:../lib/subi-connect@local-561af.tgz",
         "@tanstack/react-query": "^5.45.1",
         "@tanstack/react-table": "^8.17.3",
         "@types/node": "20.12.11",
@@ -1374,6 +1374,62 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.1.2.tgz",
+      "integrity": "sha512-9XRsLwe6Yb9B/tlnYCPVUd/TFS4J7HuOZW345DCeC6vKIxQGMZdx21RK4VoZauPD5frgkXTYVS5y90L+3YBn4w==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-popper": "1.2.0",
+        "@radix-ui/react-portal": "1.1.1",
+        "@radix-ui/react-presence": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-slot": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-visually-hidden": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.1.tgz",
+      "integrity": "sha512-A3UtLk85UtqhzFqtoC8Q0KvR2GbXF3mtPgACSazajqq6A41mEQgo53iPzY4i6BwDxlIFqWIhiQ2G729n+2aw/g==",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
@@ -1712,10 +1768,9 @@
       ]
     },
     "node_modules/@subifinancial/subi-connect": {
-      "version": "0.0.20",
-      "resolved": "file:../lib/subi-connect@local-9ed5a.tgz",
-      "integrity": "sha512-CgPnlKcs7M/v1j+mEZXVXgLxt5YJaQlTgrig50LREfWmB3FWmaJkSJlW9uLKhHboAouKVyjaaFiEMVGnPLD82g==",
-      "license": "MIT",
+      "version": "1.2.0",
+      "resolved": "file:../lib/subi-connect@local-561af.tgz",
+      "integrity": "sha512-aodV65o5YA8e54IH4UZBkYD2Et8IYmHosLjmtY6QrioKamEOGRvfc4JhAplR6Amech1aLCAxGlTxVgEyxWVh2w==",
       "dependencies": {
         "@hookform/resolvers": "^3.3.4",
         "@mdx-js/mdx": "^3.0.1",
@@ -1728,6 +1783,7 @@
         "@radix-ui/react-select": "^2.0.0",
         "@radix-ui/react-separator": "^1.0.3",
         "@radix-ui/react-slot": "^1.0.2",
+        "@radix-ui/react-tooltip": "^1.1.2-rc.1",
         "axios": "^1.7.2",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",

--- a/demo/world-pay/package.json
+++ b/demo/world-pay/package.json
@@ -11,7 +11,7 @@
     "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-switch": "^1.0.3",
-    "@subifinancial/subi-connect": "file:../lib/subi-connect@local-9ed5a.tgz",
+    "@subifinancial/subi-connect": "file:../lib/subi-connect@local-561af.tgz",
     "@tanstack/react-query": "^5.45.1",
     "@tanstack/react-table": "^8.17.3",
     "@types/node": "20.12.11",

--- a/src/components/payroll-integration/card/base-card.tsx
+++ b/src/components/payroll-integration/card/base-card.tsx
@@ -17,7 +17,7 @@ export const BaseCard: React.FC<CardProps> = ({
   return (
     <div
       className={cn(
-        'sc-flex sc-h-auto sc-w-auto sc-min-w-64 sc-max-w-md sc-flex-col sc-overflow-hidden sc-rounded-md sc-border sc-shadow-sm',
+        'sc-flex sc-h-auto sc-w-auto sc-min-w-80 sc-max-w-md sc-flex-col sc-overflow-hidden sc-rounded-md sc-border sc-shadow-sm',
       )}
     >
       <div

--- a/src/components/payroll-integration/grid.tsx
+++ b/src/components/payroll-integration/grid.tsx
@@ -43,7 +43,7 @@ const PayrollIntegrationListGrid: React.FC<PayrollIntegrationListGridProps> = ({
   return (
     <div
       className={cn(
-        'subi-connect sc-relative sc-grid sc-w-full sc-grid-cols-[repeat(auto-fill,_minmax(16rem,1fr))] sc-gap-4',
+        'subi-connect sc-relative sc-grid sc-w-full sc-grid-cols-[repeat(auto-fill,_minmax(20rem,1fr))] sc-gap-4',
         containerClassName,
       )}
     >

--- a/src/context/subi-connect.tsx
+++ b/src/context/subi-connect.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 
 type SubiConnectContext = {
   isLoading: boolean;
+  initialised: boolean;
 };
 
 export const SubiConnectContext = React.createContext<
@@ -36,6 +37,7 @@ export const SubiConnectProvider = ({
   children,
 }: SubiConnectProviderProps) => {
   const [isLoading, setIsLoading] = React.useState<boolean>(true);
+  const [initialised, setInitialised] = React.useState<boolean>(false);
 
   /**
    * Handle the connection between client and Subi Connect. Uses the provided
@@ -45,15 +47,15 @@ export const SubiConnectProvider = ({
     setIsLoading(true);
 
     /**
+     * Handle options passed to the `SubiConnectProvider`.
+     */
+    if (options) handleProviderOptions(options);
+
+    /**
      * Set the connection function on the `ConnectionService`.
      */
     const connectionService = ConnectionService.getInstance();
     connectionService.setConnectionFn(connectionFn);
-
-    /**
-     * Handle options passed to the `SubiConnectProvider`.
-     */
-    if (options) handleProviderOptions(options);
 
     /**
      * Initialise the connection between client and Subi Connect.
@@ -83,16 +85,20 @@ export const SubiConnectProvider = ({
       }
 
       setIsLoading(false);
+      if (!initialised) setInitialised(true);
     };
 
     initConnection();
   }, [connectionFn, options]);
 
-  const value = React.useMemo(() => ({ isLoading }), [isLoading]);
+  const value = React.useMemo(
+    () => ({ isLoading, initialised }),
+    [isLoading, initialised],
+  );
 
   return (
     <SubiConnectContext.Provider value={value}>
-      {children}
+      {initialised || options?.bypassInitialisation ? children : null}
     </SubiConnectContext.Provider>
   );
 };

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,4 +1,8 @@
 export { useCompany } from './use-company';
 export { useEmployees } from './use-employees';
-export { useOrganisations } from './use-organisations';
+export {
+  useOrganisations,
+  useAllOrganisations,
+  useSyncingOrganisations,
+} from './use-organisations';
 export { usePayrollSystems } from './use-payroll-systems';

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,4 +7,7 @@ export * from './hooks';
 
 export * from './types';
 
-export { SubiConnectProvider } from './context/subi-connect';
+export {
+  SubiConnectProvider,
+  type SubiConnectProviderProps,
+} from './context/subi-connect';

--- a/src/lib/handle-provider-options.tsx
+++ b/src/lib/handle-provider-options.tsx
@@ -1,6 +1,9 @@
 import axiosClient from '../services/axios';
 import logger from '../services/logger';
-import type { SubiConnectOptions } from '../types/main';
+import type {
+  SubiConnectDebugOptions,
+  SubiConnectOptions,
+} from '../types/main';
 
 /**
  * Handle all the debug options for the SubiConnectProvider.
@@ -8,7 +11,7 @@ import type { SubiConnectOptions } from '../types/main';
 const handleDebugOptions = ({
   baseURL,
   disabledLogging,
-}: SubiConnectOptions['debug']) => {
+}: SubiConnectDebugOptions) => {
   if (baseURL) axiosClient.defaults.baseURL = baseURL;
   logger.setEnabled(!disabledLogging);
 };

--- a/src/services/logger/local-logger.ts
+++ b/src/services/logger/local-logger.ts
@@ -5,13 +5,14 @@ class LocalLogger implements ILogger {
     key: string,
     customData?: Record<string, unknown>,
   ): Promise<void> {
-    const logMessage = `%c [🔗] ${key} `;
+    const logMessage = `%c [🔗] `;
 
     if (process.env.TARGET_ENV === 'local') {
       console.log(
         ...[
           logMessage,
           'color: #5E17EB; background: #E6E6EE;',
+          key,
           customData,
         ].filter(Boolean),
       );
@@ -23,13 +24,14 @@ class LocalLogger implements ILogger {
     error: Error,
     customData?: Record<string, unknown>,
   ): Promise<void> {
-    const logMessage = `%c [🔗] ${key} [${error.message}] `;
+    const logMessage = `%c [🔗🚨] `;
 
     if (process.env.TARGET_ENV === 'local') {
       console.error(
         ...[
           logMessage,
           'color: #000650; background: #FEECEC;',
+          `${key} [${error.message}]`,
           { error },
           customData,
         ].filter(Boolean),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,7 @@
-export { SelectableEmployeeColumns } from './employee';
+export * from './account';
+export * from './application';
+export * from './company';
+export * from './employee';
+export * from './main';
+export * from './organisation';
+export * from './payroll';

--- a/src/types/main.ts
+++ b/src/types/main.ts
@@ -1,20 +1,29 @@
 export type SubiConnectAccessToken = string;
 
+export type SubiConnectDebugOptions = {
+  /**
+   * Sets the base URL for the SubiConnect API.
+   */
+  baseURL?: string;
+
+  /**
+   * Disables logging to the console when TARGET_ENV = local.
+   */
+  disabledLogging?: boolean;
+};
+
 export type SubiConnectOptions = {
   /**
    * Debugging options.
    */
-  debug: {
-    /**
-     * Sets the base URL for the SubiConnect API.
-     */
-    baseURL?: string;
+  debug?: SubiConnectDebugOptions;
 
-    /**
-     * Disables logging to the console when TARGET_ENV = local.
-     */
-    disabledLogging?: boolean;
-  };
+  /**
+   * Whether or not to bypass the initialisation of the provider before
+   * rendering the children. By default, Subi Connect will wait for the
+   * initialisation process to complete before rendering the children.
+   */
+  bypassInitialisation?: boolean;
 };
 
 export enum SyncStatus {

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1,9 +1,11 @@
+/**
+ * Set all properties in T to optional, including nested properties.
+ */
 export type DeepPartial<T> = {
   [P in keyof T]?: DeepPartial<T[P]>;
 };
 
-export type OLDTypedOmit<T, K extends keyof T> = {
-  [P in Exclude<keyof T, K>]: T[P];
-};
-
+/**
+ * Omit properties from a type. Provides type typed options to exclude.
+ */
 export type TypedOmit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;


### PR DESCRIPTION
### TL;DR

This pull request aims to expose all types from the `@subifinancial/subi-connect` package.

### What changed?
- Exposed all types from the `@subifinancial/subi-connect` package
- Updated package-lock.json and package.json to reflect the new version of the package
- Made visual adjustments to some components to accommodate new types
- Enhanced the SubiConnect context to include an `initialised` state
- Updated hooks to export additional functionalities

### How to test?
1. Verify that all types are exported correctly from `@subifinancial/subi-connect`.
2. Check the visual adjustments in the relevant components.
3. Ensure that the context `initialised` state works as intended.
4. Validate the new hooks functionalities.

### Why make this change?

This change is necessary to provide full type support for the `@subifinancial/subi-connect` package.
