### PR TITLE
fix: move local logging to NODE_ENV config

### DIFF
--- a/src/services/logger/local-logger.ts
+++ b/src/services/logger/local-logger.ts
@@ -7,7 +7,7 @@ class LocalLogger implements ILogger {
   ): Promise<void> {
     const logMessage = `%c [🔗] `;
 
-    if (process.env.TARGET_ENV === 'local') {
+    if (process.env.NODE_ENV === 'development') {
       console.log(
         ...[
           logMessage,
@@ -26,7 +26,7 @@ class LocalLogger implements ILogger {
   ): Promise<void> {
     const logMessage = `%c [🔗🚨] `;
 
-    if (process.env.TARGET_ENV === 'local') {
+    if (process.env.NODE_ENV === 'development') {
       console.error(
         ...[
           logMessage,

--- a/src/types/main.ts
+++ b/src/types/main.ts
@@ -7,7 +7,8 @@ export type SubiConnectDebugOptions = {
   baseURL?: string;
 
   /**
-   * Disables logging to the console when TARGET_ENV = local.
+   * Disables logging to the console when NODE_ENV = development. Logging is
+   * not enabled in production environments.
    */
   disabledLogging?: boolean;
 };


### PR DESCRIPTION
### TL;DR
Changed environment variable references from `TARGET_ENV` to `NODE_ENV` in `LocalLogger` and main type definitions to standardize on the use of `NODE_ENV` for environment-specific logic.

### What changed?
Replaced all occurrences of `TARGET_ENV === 'local'` with `NODE_ENV === 'development'` in `LocalLogger` class and updated comments in main type definitions.

### How to test?
1. Set `NODE_ENV` to `development`.
2. Run the application and observe that logging is directed to the console.
3. Set `NODE_ENV` to `production`.
4. Run the application and confirm that logging is disabled.

### Why make this change?
To ensure consistent usage of the `NODE_ENV` environment variable for environment-specific conditions and to follow common Node.js practices.