### PR TITLE
Add useCompanyPayrollIntegrations hook for company integrations

### DIFF
--- a/.changeset/nervous-laws-cross.md
+++ b/.changeset/nervous-laws-cross.md
@@ -1,0 +1,6 @@
+---
+'@subifinancial/subi-connect': minor
+---
+
+Add a new company hook (useCompanyPayrollIntegrations) that is used to get all
+the integrations the company has connected with. 

--- a/demo/world-pay/package-lock.json
+++ b/demo/world-pay/package-lock.json
@@ -9,7 +9,7 @@
         "@radix-ui/react-label": "^2.0.2",
         "@radix-ui/react-slot": "^1.0.2",
         "@radix-ui/react-switch": "^1.0.3",
-        "@subifinancial/subi-connect": "file:../lib/subi-connect@local-561af.tgz",
+        "@subifinancial/subi-connect": "file:../lib/subi-connect@local-3dfb2.tgz",
         "@tanstack/react-query": "^5.45.1",
         "@tanstack/react-table": "^8.17.3",
         "@types/node": "20.12.11",
@@ -1768,9 +1768,9 @@
       ]
     },
     "node_modules/@subifinancial/subi-connect": {
-      "version": "1.2.0",
-      "resolved": "file:../lib/subi-connect@local-561af.tgz",
-      "integrity": "sha512-aodV65o5YA8e54IH4UZBkYD2Et8IYmHosLjmtY6QrioKamEOGRvfc4JhAplR6Amech1aLCAxGlTxVgEyxWVh2w==",
+      "version": "1.4.5",
+      "resolved": "file:../lib/subi-connect@local-3dfb2.tgz",
+      "integrity": "sha512-xQBOU4Am6k3Z5BB7gmnn54g+gEvEcWSuEzpIUq52tR5uFuxtXrGeYLWi5rUtkJi5YO1ipapioXGtaYtyL9j2nA==",
       "dependencies": {
         "@hookform/resolvers": "^3.3.4",
         "@mdx-js/mdx": "^3.0.1",

--- a/demo/world-pay/package.json
+++ b/demo/world-pay/package.json
@@ -11,7 +11,7 @@
     "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-switch": "^1.0.3",
-    "@subifinancial/subi-connect": "file:../lib/subi-connect@local-561af.tgz",
+    "@subifinancial/subi-connect": "file:../lib/subi-connect@local-3dfb2.tgz",
     "@tanstack/react-query": "^5.45.1",
     "@tanstack/react-table": "^8.17.3",
     "@types/node": "20.12.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@subifinancial/subi-connect",
-  "version": "1.3.0",
+  "version": "1.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@subifinancial/subi-connect",
-      "version": "1.3.0",
+      "version": "1.4.5",
       "license": "MIT",
       "dependencies": {
         "@hookform/resolvers": "^3.3.4",

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,4 +1,4 @@
-export { useCompany } from './use-company';
+export { useCompany, useCompanyPayrollIntegrations } from './use-company';
 export { useEmployees } from './use-employees';
 export {
   useOrganisations,

--- a/src/hooks/use-company.tsx
+++ b/src/hooks/use-company.tsx
@@ -1,4 +1,8 @@
-import { getCompany } from '../services/api/company/actions';
+import {
+  getCompany,
+  getCompanyPayrollIntegrations,
+} from '../services/api/company/actions';
+import type { Payroll } from '../types';
 import type { Company } from '../types/company';
 import type { BaseQueryOptions } from '../types/query';
 import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
@@ -10,12 +14,34 @@ type UseCompanyOptions = {
 };
 
 export const useCompany = (options?: UseCompanyOptions) => {
-  // No need to add the company id to the query key because there will only be
-  // one company in the context
+  /**
+   * No need to add the company id to the query key because there will only be
+   * one company in the context
+   */
   const queryKey = [...BASE_COMPANY_QUERY_KEY, 'detail'] as const;
   return useQuery({
     queryKey: queryKey,
     queryFn: getCompany,
+    ...options?.queryOptions,
+  });
+};
+
+const BASE_COMPANY_PAYROLL_INTEGRATIONS_QUERY_KEY = [
+  'subi-connect',
+  'company-payroll-integrations',
+] as const;
+
+type UseCompanyPayrollIntegrationsOptions = {
+  queryOptions?: BaseQueryOptions<UseQueryOptions<Payroll[] | null>>;
+};
+
+export const useCompanyPayrollIntegrations = (
+  options?: UseCompanyPayrollIntegrationsOptions,
+) => {
+  const queryKey = [...BASE_COMPANY_PAYROLL_INTEGRATIONS_QUERY_KEY] as const;
+  return useQuery({
+    queryKey: queryKey,
+    queryFn: getCompanyPayrollIntegrations,
     ...options?.queryOptions,
   });
 };

--- a/src/services/api/company/actions.ts
+++ b/src/services/api/company/actions.ts
@@ -1,8 +1,9 @@
 import { constructAPIURL } from '..';
 import { ACCESS_TOKEN_NAME } from '../../../constants';
+import type { Payroll } from '../../../types';
 import type { Company } from '../../../types/company';
 import axiosClient from '../../axios';
-import { COMPANY_URL } from './paths';
+import { COMPANY_PAYROLL_INTEGRATIONS_URL, COMPANY_URL } from './paths';
 
 /**
  * Gets the company that is attached to the authorisation headers.
@@ -14,4 +15,18 @@ export const getCompany = async (): Promise<Company> => {
     { headers: { Authorization: `Bearer ${accessToken}` } },
   );
   return response.data;
+};
+
+/**
+ * Get the company's payroll systems they have connected to.
+ * @returns a list of connected payroll systems.
+ */
+export const getCompanyPayrollIntegrations = async (): Promise<
+  Payroll[] | null
+> => {
+  const response = await axiosClient.get<{ integrations: Payroll[] | null }>(
+    constructAPIURL(COMPANY_PAYROLL_INTEGRATIONS_URL),
+  );
+
+  return response.data.integrations;
 };

--- a/src/services/api/company/paths.ts
+++ b/src/services/api/company/paths.ts
@@ -1,1 +1,2 @@
 export const COMPANY_URL = 'company';
+export const COMPANY_PAYROLL_INTEGRATIONS_URL = 'company/integrations';


### PR DESCRIPTION
### TL;DR

Added a new hook `useCompanyPayrollIntegrations` to fetch company's connected payroll integrations.

### What changed?

- Introduced a new hook `useCompanyPayrollIntegrations` in `use-company.tsx`
- Added a new API action `getCompanyPayrollIntegrations` in `company/actions.ts`
- Created a new API path `COMPANY_PAYROLL_INTEGRATIONS_URL` in `company/paths.ts`
- Exported the new hook from `hooks/index.ts`

### How to test?

1. Import the `useCompanyPayrollIntegrations` hook in a component
2. Use the hook to fetch payroll integrations data
3. Verify that the hook returns the expected data structure (Payroll[] | null)
4. Check that the API call is made to the correct endpoint (/company/integrations)

### Why make this change?

This change allows developers to easily fetch and display the payroll integrations that a company has connected with. It enhances the functionality of the Subi Connect library by providing a dedicated hook for accessing this specific data, improving the overall developer experience and making it easier to manage company-related information.