### PR TITLE
Disable autocomplete for API key and domain inputs

### DIFF
--- a/.changeset/chatty-beers-sell.md
+++ b/.changeset/chatty-beers-sell.md
@@ -1,0 +1,8 @@
+---
+'@subifinancial/subi-connect': patch
+---
+
+Update the input components to not auto-complete.
+- Update ApiKeyInput
+- Update DomainInput
+- Update the stories to correctly test the inputs in a form context

--- a/src/components/employees-table/columns/company-specific.tsx
+++ b/src/components/employees-table/columns/company-specific.tsx
@@ -7,7 +7,7 @@ import { emailColumn, fullNameColumn } from './core';
 import React from 'react';
 
 const SyncStatusDescription = () => (
-  <div className='_sc-max-w-full _sc-w-auto sc-whitespace-normal sc-text-wrap sc-break-words sc-p-2 sc-text-xs sc-font-normal'>
+  <div className='sc-whitespace-normal sc-text-wrap sc-break-words sc-p-2 sc-text-xs sc-font-normal'>
     <h4 className='sc-text-base sc-font-bold'>Sync Status</h4>
     <ul className='sc-list-inside'>
       <li className='sc-indent-1'>

--- a/src/components/payroll-integration-instructions/api-input.tsx
+++ b/src/components/payroll-integration-instructions/api-input.tsx
@@ -5,25 +5,13 @@ import React from 'react';
 type ApiKeyInputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 const ApiKeyInput = React.forwardRef<HTMLInputElement, ApiKeyInputProps>(
-  ({ value = '', onChange, className, ...props }, ref) => {
-    const [internalValue, setInternalValue] = React.useState(value);
+  ({ className, ...props }, ref) => {
     const [isHovered, setIsHovered] = React.useState(false);
-
-    const inputType: 'text' | 'password' = React.useMemo(() => {
-      return isHovered ? 'text' : 'password';
-    }, [isHovered]);
-
-    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-      setInternalValue(e.target.value);
-      onChange?.(e);
-    };
 
     return (
       <Input
         {...props}
-        type={inputType}
-        value={internalValue}
-        onChange={handleChange}
+        type={isHovered ? 'text' : 'password'}
         placeholder='Enter API Key'
         ref={ref}
         onMouseEnter={() => setIsHovered(true)}

--- a/src/components/payroll-integration-instructions/domain-input.stories.tsx
+++ b/src/components/payroll-integration-instructions/domain-input.stories.tsx
@@ -1,22 +1,51 @@
+import { Button } from '../../ui/button';
+import { Form } from '../../ui/form';
 import DomainInput from './domain-input';
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
-import { useForm, FormProvider } from 'react-hook-form';
+import { useForm } from 'react-hook-form';
 
 const meta: Meta<typeof DomainInput> = {
   title: 'Form Components/DomainInput',
   component: DomainInput,
   tags: ['autodocs'],
   decorators: [
-    (Story): React.ReactElement => {
-      const methods = useForm();
+    (_, { args }): React.ReactElement => {
+      const form = useForm<{ domain: string }>();
+      const { register, handleSubmit } = form;
+      const [formData, setFormData] = React.useState<string | null>(null);
+
+      const handleOnSubmit = (data: { domain: string }) => {
+        setFormData(JSON.stringify(data, null, 2));
+      };
+
       return (
-        <FormProvider {...methods}>
-          <form onSubmit={methods.handleSubmit((data) => console.log(data))}>
-            <Story />
-            <button type='submit'>Submit</button>
-          </form>
-        </FormProvider>
+        <div
+          id='subi-connect-payroll-integration-worflow'
+          className='subi-connect sc-h-full sc-w-full sc-p-2'
+        >
+          <Form {...form}>
+            <form
+              onSubmit={handleSubmit(handleOnSubmit)}
+              className='sc-flex sc-flex-col sc-gap-2'
+              autoComplete='off'
+            >
+              <DomainInput
+                {...register('domain')}
+                domainContext={args.domainContext}
+                id='search_subi-connect-payroll-integration-worflow_domain'
+              />
+              <Button type='submit' className='sc-mt-4'>
+                Finish
+              </Button>
+              {formData && (
+                <pre className='sc-mt-4 sc-rounded sc-bg-gray-100 sc-p-2'>
+                  {formData}
+                </pre>
+              )}
+            </form>
+          </Form>
+        </div>
       );
     },
   ],
@@ -27,7 +56,6 @@ type Story = StoryObj<typeof DomainInput>;
 
 export const Default: Story = {
   args: {
-    name: 'domain',
     domainContext: 'example.com',
   },
 };

--- a/src/components/payroll-integration-instructions/domain-input.tsx
+++ b/src/components/payroll-integration-instructions/domain-input.tsx
@@ -24,18 +24,19 @@ const DomainInput = React.forwardRef<HTMLInputElement, DomainInputProps>(
 
     const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
       const input = e.target.value;
-      const subdomain = extractSubdomain(input);
+
+      const subdomain = extractSubdomain(input.replace(/\s/g, ''));
 
       e.target.value = subdomain;
       setSubDomain(subdomain);
-
       onChange?.(e);
     };
 
     return (
-      <div className='sc-relative sc-flex sc-w-full sc-overflow-clip'>
+      <div className='sc-relative sc-mb-2 sc-flex sc-w-full sc-flex-col sc-items-start sc-gap-4 sc-overflow-clip'>
         <Input
           {...props}
+          type='text'
           placeholder='Enter Subdomain'
           ref={ref}
           onChange={handleInputChange}
@@ -45,7 +46,7 @@ const DomainInput = React.forwardRef<HTMLInputElement, DomainInputProps>(
         />
         <div
           className={cn(
-            'sc-absolute sc-right-2 sc-top-1/2 sc-ml-1 sc-hidden sc-h-4 -sc-translate-y-1/2 sc-items-center sc-justify-center sc-bg-background sc-px-1 sc-text-xs sc-text-gray-500 sm:sc-flex',
+            'sc-relative sc-right-2 sc-top-1/2 sc-ml-1 sc-flex sc-h-3/4 -sc-translate-y-1/2 sc-items-center sc-justify-center sc-bg-background sc-px-1 sc-text-xs sc-text-gray-500 sm:sc-absolute',
             {
               'sc-hidden sm:sc-hidden': !subDomain || !domainContext,
             },

--- a/src/components/payroll-integration-instructions/inputs.stories.tsx
+++ b/src/components/payroll-integration-instructions/inputs.stories.tsx
@@ -1,24 +1,32 @@
 import { Button } from '../../ui/button';
 import { Form } from '../../ui/form';
 import ApiKeyInput from './api-input';
+import DomainInput from './domain-input';
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 import { useForm } from 'react-hook-form';
 
-const meta: Meta<typeof ApiKeyInput> = {
-  title: 'Form Components/ApiKeyInput',
-  component: ApiKeyInput,
+type PropsAndCustomArgs = React.ComponentProps<typeof Form> & {
+  domainContext: string;
+};
+
+const meta: Meta = {
+  title: 'Form Components/Inputs',
   tags: ['autodocs'],
+  component: Form,
+  subcomponents: {
+    ApiKeyInput: ApiKeyInput as React.ComponentType<unknown>,
+    DomainInput: DomainInput as React.ComponentType<unknown>,
+  },
   decorators: [
-    (): React.ReactElement => {
-      const form = useForm<{ apiKey: string }>();
+    (_, { args }): React.ReactElement => {
+      const form = useForm<{ apiKey: string; domain: string }>();
+      const { register, handleSubmit } = form;
       const [formData, setFormData] = React.useState<string | null>(null);
 
-      const handleOnSubmit = (data: { apiKey: string }) => {
+      const handleOnSubmit = (data: { apiKey: string; domain: string }) => {
         setFormData(JSON.stringify(data, null, 2));
       };
-
-      const { register, handleSubmit } = form;
 
       return (
         <div
@@ -35,10 +43,14 @@ const meta: Meta<typeof ApiKeyInput> = {
                 {...register('apiKey')}
                 id='search_subi-connect-payroll-integration-worflow_apiKey'
               />
+              <DomainInput
+                {...register('domain')}
+                domainContext={args.domainContext}
+                id='search_subi-connect-payroll-integration-worflow_domain'
+              />
               <Button type='submit' className='sc-mt-4'>
                 Finish
               </Button>
-
               {formData && (
                 <pre className='sc-mt-4 sc-rounded sc-bg-gray-100 sc-p-2'>
                   {formData}
@@ -53,8 +65,10 @@ const meta: Meta<typeof ApiKeyInput> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof ApiKeyInput>;
+type Story = StoryObj<PropsAndCustomArgs>;
 
 export const Default: Story = {
-  name: 'Default',
+  args: {
+    domainContext: 'example.com',
+  },
 };

--- a/src/index.css
+++ b/src/index.css
@@ -135,4 +135,12 @@
   strong {
     @apply sc-font-mainMedium sc-font-normal;
   }
+
+  /* Hide the auto-fill button in Safari */
+  input::-webkit-contacts-auto-fill-button,
+  input::-webkit-credentials-auto-fill-button {
+    visibility: hidden;
+    position: absolute;
+    top: -50px;
+  }
 }

--- a/src/integration-pages/custom/index.tsx
+++ b/src/integration-pages/custom/index.tsx
@@ -97,7 +97,15 @@ export const CustomPayrollIntegrationWorkflow: React.FC<CustomPayrollIntegration
                 React.InputHTMLAttributes<HTMLInputElement>
               >,
             ) => (
-              <Component {...props} {...register(key, { required: true })} />
+              <Component
+                {...props}
+                {...register(key, { required: true })}
+                /**
+                 * search_... is a workaround to prevent the input from being
+                 * autocompleted by some browsers.
+                 */
+                id={`search_subi-connect-payroll-integration-worflow_${key}`}
+              />
             );
             return acc;
           },
@@ -128,13 +136,14 @@ export const CustomPayrollIntegrationWorkflow: React.FC<CustomPayrollIntegration
           <form
             onSubmit={handleSubmit(handleOnSubmit)}
             className='sc-flex sc-flex-col sc-gap-2'
+            autoComplete='off'
           >
             <RenderMDX
               mdxString={payrollSystem.mdxIntegrationInstructions}
               components={components}
             />
 
-            <FormField name='root' render={() => <FormMessage />}></FormField>
+            <FormField name='root' render={() => <FormMessage />} />
 
             <Button type='submit' className='sc-mt-4' disabled={isPending}>
               Finish

--- a/src/ui/data-table-toolbar.tsx
+++ b/src/ui/data-table-toolbar.tsx
@@ -73,7 +73,7 @@ export function DataTableToolbar<TData, TCreate>({
               className='sc-h-8 sc-w-[150px] sc-pr-7 lg:sc-w-[250px]'
             />
 
-            <div className='_sc-pl-2 sc-absolute sc-right-0 sc-mx-2 sc-flex sc-h-fit sc-w-fit sc-items-center sc-justify-center sc-rounded-full sc-bg-background sc-pt-[0.125rem]'>
+            <div className='sc-absolute sc-right-0 sc-mx-2 sc-flex sc-h-fit sc-w-fit sc-items-center sc-justify-center sc-rounded-full sc-bg-background sc-pt-[0.125rem]'>
               <LoaderCircleIcon
                 className={cn(
                   'sc-hidden sc-h-3 sc-w-3 sc-text-muted-foreground/50',

--- a/src/ui/extended/table/columns/sync/sync-status.tsx
+++ b/src/ui/extended/table/columns/sync/sync-status.tsx
@@ -1,6 +1,3 @@
-import type { Cell, Column, Row } from '@tanstack/react-table';
-import { CircleAlertIcon, CircleCheck, LoaderCircleIcon } from 'lucide-react';
-import React from 'react';
 import type { ColumnDef } from '../../../../../types/components/data-table';
 import { SyncStatus } from '../../../../../types/main';
 import { DataTableColumnHeader } from '../../../../data-table-column-header';
@@ -16,6 +13,9 @@ import {
   type BaseLastSyncedColumnNestedType,
   type BaseLastSyncedColumnType,
 } from './types';
+import type { Cell, Column, Row } from '@tanstack/react-table';
+import { CircleAlertIcon, CircleCheck, LoaderCircleIcon } from 'lucide-react';
+import React from 'react';
 
 type SyncStatusColumnProps<T> = ColumnDef<T> & {
   accessorKey: `${string}.sync` | keyof T;
@@ -122,7 +122,7 @@ const SyncStatusHeader = <T,>({
             className='sc-flex sc-justify-end'
           />
         </TooltipTrigger>
-        <TooltipContent side='bottom' align='end' className='_sc-mx-2'>
+        <TooltipContent side='bottom' align='end'>
           {description}
         </TooltipContent>
       </Tooltip>


### PR DESCRIPTION
### TL;DR

Updated input components to prevent auto-completion and improved form handling in stories.

### What changed?

- Modified ApiKeyInput and DomainInput components to disable auto-completion
- Updated stories for ApiKeyInput, DomainInput, and created a new combined Inputs story
- Adjusted form handling in stories to use React Hook Form and display submitted data
- Added CSS to hide auto-fill buttons in Safari

### How to test?

1. Run the Storybook and navigate to the Form Components section
2. Test the ApiKeyInput, DomainInput, and combined Inputs stories
3. Verify that auto-completion is disabled for both inputs
4. Submit the forms and check if the entered data is correctly displayed
5. Test in Safari to ensure auto-fill buttons are hidden

### Why make this change?

This change improves the user experience and security of the input components by preventing unwanted auto-completion. It also enhances the testing capabilities in Storybook by providing more realistic form scenarios and displaying submitted data.