### PR TITLE
chore: add env to deploy demos script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,5 @@
 name: Deploy Demos
+run-name: Deploy Demos → ${{ github.event.inputs.env }}
 
 on:
   workflow_dispatch:
@@ -108,7 +109,7 @@ jobs:
           path: ./demo/world-pay/dist
 
   deploy-demo:
-    name: ✈️ Deploy subi-connect demo
+    name: 🛫 Deploy subi-connect demo
     runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.env }}-ap-southeast-2
     needs: [build-demo]


### PR DESCRIPTION
### TL;DR

Enhanced GitHub Actions workflow for deploying demos with improved visibility and naming.

### What changed?

- Added a `run-name` to the workflow, which now displays the target environment in the GitHub Actions UI.
- Updated the emoji for the "Deploy subi-connect demo" job from ✈️ to 🛫 for better visual distinction.

### How to test?

1. Trigger the workflow manually in GitHub Actions.
2. Verify that the new run name appears in the Actions tab, showing the target environment.
3. Check that the "Deploy subi-connect demo" job now displays the 🛫 emoji instead of ✈️.

### Why make this change?

These updates improve the workflow's visibility and readability in the GitHub Actions UI. The dynamic run name provides immediate context about the deployment target, while the updated emoji offers better visual differentiation for the specific deployment job.