### PR TITLE
chore: update workflows to deploy all demos on version bump

### DIFF
--- a/.github/workflows/deploy-all-demos.yml
+++ b/.github/workflows/deploy-all-demos.yml
@@ -1,0 +1,17 @@
+name: Deploy Demos to All Environments
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  deploy-all:
+    strategy:
+      matrix:
+        env: [dev, stg, prod]
+    uses: ./.github/workflows/deploy.yml
+    with:
+      env: ${{ matrix.env }}
+    secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,13 @@
 name: Deploy Demos
-run-name: Deploy Demos → ${{ github.event.inputs.env }}
+run-name: Deploy Demos → ${{ inputs.env }}
 
 on:
+  workflow_call:
+    inputs:
+      env:
+        type: string
+        description: 'Select the environment'
+        required: true
   workflow_dispatch:
     inputs:
       env:
@@ -14,7 +20,7 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.event.inputs.env }}
+  group: deploy-${{ inputs.env }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
### TL;DR

Added a new workflow for deploying demos to all environments and updated the existing deploy workflow to support reusability.

### What changed?

- Created a new workflow file `deploy-all-demos.yml` that triggers deployments to all environments (dev, stg, prod) on workflow dispatch or when a new tag is pushed.
- Modified the existing `deploy.yml` workflow to support being called by other workflows.
- Updated the `deploy.yml` workflow to use `inputs.env` instead of `github.event.inputs.env` for broader compatibility.
- Adjusted the concurrency group in `deploy.yml` to use the new input format.

### How to test?

1. Manually trigger the new "Deploy Demos to All Environments" workflow from the Actions tab.
2. Push a new tag (e.g., `v1.0.0`) to trigger automatic deployment to all environments.
3. Verify that the existing manual deployment workflow still functions correctly for individual environments.

### Why make this change?

This change streamlines the deployment process by allowing simultaneous deployments to all environments with a single action. It also improves the reusability of the existing deployment workflow, making it easier to maintain and extend in the future.