### PR TITLE
chore (workflows): update deployment build artifact name to include env

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
   build-lib-tgz:
     name: 🏗️ Build subi-connect lib
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.env }}-ap-southeast-2
+    environment: ${{ inputs.env }}-ap-southeast-2
     env:
       SUBI_CONNECT_IMAGES_BASE_URL: ${{ secrets.SUBI_CONNECT_IMAGES_BASE_URL }}
       SUBI_CONNECT_PUBLIC_BASE_URL: ${{ secrets.SUBI_CONNECT_PUBLIC_BASE_URL }}
@@ -57,21 +57,21 @@ jobs:
 
       - name: Build
         run: |
-          npm run pack ${{ github.event.inputs.env }}
+          npm run pack ${{ inputs.env }}
           export SUBI_CONNECT_TGZ_AUX_FILE_NAME=$(ls -t ${{ env.SUBI_CONNECT_PACK_DESTINATION }}/subi-connect*.tgz | head -n 1)
           echo "Generated package: $SUBI_CONNECT_TGZ_AUX_FILE_NAME"
 
       - name: Save Build as Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: subiconnect-lib
+          name: subiconnect-lib-${{ inputs.env }}
           path: ${{ env.SUBI_CONNECT_PACK_DESTINATION }}
 
   build-demo:
     name: 🏗️ Build subi-connect demo
     runs-on: ubuntu-latest
     needs: [build-lib-tgz]
-    environment: ${{ github.event.inputs.env }}-ap-southeast-2
+    environment: ${{ inputs.env }}-ap-southeast-2
     env:
       VITE_AUTH0_AUDIENCE: ${{ secrets.VITE_AUTH0_AUDIENCE }}
       VITE_AUTH0_CLIENT_ID: ${{ secrets.VITE_AUTH0_CLIENT_ID }}
@@ -95,7 +95,7 @@ jobs:
       - name: Download subi-connect-lib artifacts
         uses: actions/download-artifact@v4
         with:
-          name: subiconnect-lib
+          name: subiconnect-lib-${{ inputs.env }}
           path: ${{ env.SUBI_CONNECT_PACK_DESTINATION }}
 
       - name: Install packages
@@ -117,7 +117,7 @@ jobs:
   deploy-demo:
     name: 🛫 Deploy subi-connect demo
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.env }}-ap-southeast-2
+    environment: ${{ inputs.env }}-ap-southeast-2
     needs: [build-demo]
     permissions:
       id-token: write
@@ -144,7 +144,7 @@ jobs:
   invalidate-demo-cache:
     name: 🧹 Invalidate subi-connect demo cache
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.env }}-ap-southeast-2
+    environment: ${{ inputs.env }}-ap-southeast-2
     needs: [deploy-demo]
     permissions:
       id-token: write


### PR DESCRIPTION
### TL;DR

Updated GitHub Actions workflow to use `inputs.env` instead of `github.event.inputs.env` and modified artifact naming.

### What changed?

- Replaced `${{ github.event.inputs.env }}` with `${{ inputs.env }}` throughout the workflow file.
- Updated the artifact name for the subi-connect library to include the environment: `subiconnect-lib-${{ inputs.env }}`.
- Adjusted the download artifact step in the build-demo job to use the new artifact name.

### How to test?

1. Trigger the workflow manually with different environment inputs.
2. Verify that the correct environment is used throughout the workflow.
3. Check that the artifacts are correctly named and downloaded in subsequent jobs.
4. Ensure the demo builds and deploys successfully for each environment.

### Why make this change?

This change improves the workflow's flexibility and clarity by:
1. Directly using the `inputs` context, which is more appropriate for reusable workflows.
2. Enhancing artifact naming to include the environment, making it easier to identify and manage artifacts for different environments.
3. Ensuring consistency across jobs when referencing the environment variable.