### PR TITLE
chore (workflows): update demo deployement build artifact to include env

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Save Build as Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: subiconnect-demo
+          name: subiconnect-demo-${{ inputs.env }}
           path: ./demo/world-pay/dist
 
   deploy-demo:
@@ -126,7 +126,7 @@ jobs:
       - name: Download Build Artifacts
         uses: actions/download-artifact@v4
         with:
-          name: subiconnect-demo
+          name: subiconnect-demo-${{ inputs.env }}
           path: demo-dist
 
       - name: Configure aws credentials


### PR DESCRIPTION
### TL;DR

Updated artifact naming in GitHub Actions workflow to include environment.

### What changed?

- Modified the artifact name in the "Save Build as Artifact" step to include the environment variable: `subiconnect-demo-${{ inputs.env }}`
- Updated the corresponding artifact name in the "Download Build Artifacts" step to match the new naming convention

### How to test?

1. Trigger the GitHub Actions workflow for different environments
2. Verify that the artifact names include the environment identifier
3. Ensure the "Download Build Artifacts" step successfully retrieves the correctly named artifact

### Why make this change?

This change allows for better differentiation between artifacts from different environments, improving clarity and reducing the risk of deploying the wrong build to a specific environment.