### PR TITLE
fix: domain input ui/ux

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   lint:
-    name: Build subi-connect lib
+    name: 🧼 Lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/src/components/payroll-integration-instructions/domain-input.tsx
+++ b/src/components/payroll-integration-instructions/domain-input.tsx
@@ -33,7 +33,7 @@ const DomainInput = React.forwardRef<HTMLInputElement, DomainInputProps>(
     };
 
     return (
-      <div className='sc-relative sc-mb-2 sc-flex sc-w-full sc-flex-col sc-items-start sc-gap-4 sc-overflow-clip'>
+      <div className='sc-relative sc-mb-2 sc-flex sc-w-full sc-flex-col sc-items-start sc-gap-4 sc-overflow-visible'>
         <Input
           {...props}
           type='text'
@@ -46,7 +46,7 @@ const DomainInput = React.forwardRef<HTMLInputElement, DomainInputProps>(
         />
         <div
           className={cn(
-            'sc-relative sc-right-2 sc-top-1/2 sc-ml-1 sc-flex sc-h-3/4 -sc-translate-y-1/2 sc-items-center sc-justify-center sc-bg-background sc-px-1 sc-text-xs sc-text-gray-500 sm:sc-absolute',
+            'sm:sc-max-w-1/2 sc-relative sc-right-0 sc-top-1/2 sc-flex sc-h-3/4 sc-max-w-full -sc-translate-y-1/2 sc-items-center sc-justify-start sc-overflow-x-scroll sc-bg-background sc-text-xs sc-text-gray-500 sm:sc-absolute sm:sc-right-2 sm:sc-pl-2',
             {
               'sc-hidden sm:sc-hidden': !subDomain || !domainContext,
             },


### PR DESCRIPTION
### TL;DR

Updated GitHub Actions workflow and improved domain input component styling.

### What changed?

- Renamed the lint job in the GitHub Actions workflow to "🧼 Lint"
- Modified the styling of the domain input component:
  - Changed the overflow property from `clip` to `visible` for the main container
  - Updated the styling for the subdomain display, improving responsiveness and scroll behaviour

### How to test?

1. Review the GitHub Actions workflow to ensure the lint job is correctly named
2. Test the domain input component on various screen sizes:
   - Verify that the subdomain display is visible and scrollable on smaller screens
   - Confirm that the subdomain display is properly positioned on larger screens
3. Check that the overflow behaviour of the domain input component is correct

### Why make this change?

- The workflow rename provides a clearer indication of the job's purpose
- The styling updates improve the usability and responsiveness of the domain input component, especially on smaller screens
- These changes enhance the overall user experience and maintainability of the codebase