### PR TITLE
fix: add CustomLink to alter the default behaviour of 'a' tags in integration instructions

### DIFF
--- a/.changeset/unlucky-needles-sin.md
+++ b/.changeset/unlucky-needles-sin.md
@@ -1,0 +1,17 @@
+---
+'@subifinancial/subi-connect': patch
+---
+
+### TL;DR
+
+- Added a CustomLink component and updated the components map and CSS styles.
+- Improved domain input component styling.
+
+### What changed?
+
+- Created a new `CustomLink` component in `custom-link.tsx`
+    - Added `CustomLink` to the `otherComponentsMap` in `components-map.tsx`
+- Modified the CSS in `index.css` to apply the font-family directly to the `.subi-connect` class instead of all its children
+- Modified the styling of the domain input component:
+    -  Changed the overflow property from clip to visible for the main container
+    - Updated the styling for the subdomain display, improving responsiveness and scroll behaviour

--- a/src/components/payroll-integration-instructions/components-map.tsx
+++ b/src/components/payroll-integration-instructions/components-map.tsx
@@ -1,4 +1,5 @@
 import ApiKeyInput from './api-input';
+import CustomLink from './custom-link';
 import DomainInput from './domain-input';
 import VideoTutorial from './video-tutorial';
 import React from 'react';
@@ -15,5 +16,6 @@ export const otherComponentsMap: Record<
   string,
   React.FunctionComponent<any> // eslint-disable-line @typescript-eslint/no-explicit-any
 > = {
+  a: CustomLink,
   VideoTutorial,
 };

--- a/src/components/payroll-integration-instructions/custom-link.tsx
+++ b/src/components/payroll-integration-instructions/custom-link.tsx
@@ -1,0 +1,17 @@
+import type { TypedOmit } from '../../types/utils';
+import React from 'react';
+
+type CustomLinkProps = TypedOmit<
+  React.ComponentPropsWithoutRef<'a'>,
+  'rel' | 'target'
+>;
+
+const CustomLink: React.FC<CustomLinkProps> = ({ children, ...props }) => {
+  return (
+    <a {...props} rel='noopener noreferrer' target='_blank'>
+      {children}
+    </a>
+  );
+};
+
+export default CustomLink;

--- a/src/index.css
+++ b/src/index.css
@@ -89,9 +89,7 @@
 /* Scoped Styles */
 @layer components {
   .subi-connect {
-    * {
-      font-family: 'Moderat-Light', sans-serif;
-    }
+    font-family: 'Moderat-Light', sans-serif;
 
     [data-radix-popper-content-wrapper] {
       min-width: auto !important;


### PR DESCRIPTION
### TL;DR

Added a CustomLink component and updated the components map and CSS styles.

### What changed?

- Created a new `CustomLink` component in `custom-link.tsx`
- Added `CustomLink` to the `otherComponentsMap` in `components-map.tsx`
- Modified the CSS in `index.css` to apply the font-family directly to the `.subi-connect` class instead of all its children

### How to test?

1. Verify that the `CustomLink` component renders correctly when used in the payroll integration instructions.
2. Check that links open in a new tab with the appropriate `rel` attribute.
3. Ensure that the font-family is applied correctly to the `.subi-connect` class and its children.

### Why make this change?

The `CustomLink` component was added to provide a consistent and secure way to render external links within the payroll integration instructions. This ensures that all links open in a new tab and have the appropriate `rel` attribute for security.

The CSS change simplifies the font-family application and potentially improves performance by reducing the specificity of the selector.