### PR TITLE
chore (workflows): update deploy all demos workflow to run on package release

### DIFF
--- a/.github/workflows/deploy-all-demos.yml
+++ b/.github/workflows/deploy-all-demos.yml
@@ -2,9 +2,8 @@ name: Deploy Demos to All Environments
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
 
 jobs:
   deploy-all:


### PR DESCRIPTION
### TL;DR

Updated the trigger for the "Deploy Demos to All Environments" workflow.

### What changed?

Modified the workflow trigger from push events on tags starting with 'v' to release events of type 'published'.

### How to test?

1. Create a new release in the repository.
2. Publish the release.
3. Verify that the "Deploy Demos to All Environments" workflow is triggered automatically.

### Why make this change?

This change ensures that the deployment workflow is triggered only when a release is published, rather than on every tag push. This provides more control over when deployments occur and aligns the process with the release lifecycle.