### PR TITLE
fix: update integration dialogue instructions max width

### DIFF
--- a/.changeset/wicked-shoes-compete.md
+++ b/.changeset/wicked-shoes-compete.md
@@ -1,0 +1,5 @@
+---
+'@subifinancial/subi-connect': patch
+---
+
+Increased the maximum width of the dialogue content for larger screens.

--- a/src/components/connect-and-integrate/index.tsx
+++ b/src/components/connect-and-integrate/index.tsx
@@ -145,7 +145,7 @@ const Integrate: React.FC<{
       </DialogueTrigger>
       <DialogueContent
         aria-describedby='A dialogue to connect and integrate with a payroll system'
-        className='sc-flex sc-h-auto sc-max-h-[80%] sc-w-10/12 sc-max-w-xl sc-flex-col sc-overflow-y-auto md:sc-max-w-2xl'
+        className='sc-flex sc-h-auto sc-max-h-[80%] sc-w-10/12 sc-max-w-xl sc-flex-col sc-overflow-y-auto md:sc-max-w-4xl'
       >
         <DialogueTitle className='sc-sr-only'>
           Connect and Integrate {payrollSystem.name}


### PR DESCRIPTION
### TL;DR

Increased the maximum width of the dialogue content for larger screens.

### What changed?

Modified the `className` prop of the `DialogueContent` component in the `Integrate` component. Specifically, the `md:sc-max-w-2xl` class was changed to `md:sc-max-w-4xl`, increasing the maximum width for medium and larger screens.

### How to test?

1. Navigate to the page containing the Connect and Integrate component.
2. Trigger the dialogue to open.
3. Resize the browser window to a medium or larger screen size.
4. Verify that the dialogue content expands to a wider maximum width compared to before.

### Why make this change?

This change was likely made to improve the user experience on larger screens by allowing more content to be displayed horizontally. The increased width can potentially reduce vertical scrolling and make better use of available screen space, especially for users with wider monitors or higher-resolution displays.