### PR TITLE
fix: remove subi-connect class from components inside provider div container

### DIFF
--- a/.changeset/silly-penguins-love.md
+++ b/.changeset/silly-penguins-love.md
@@ -1,0 +1,8 @@
+---
+'@subifinancial/subi-connect': patch
+---
+
+Remove 'subi-connect' class from components inside provider div container.
+- The 'subi-connect' class is now only applied to the 
+    - provider div container [@src/context/subi-connect.tsx]
+    - dialogue component [@src/ui/dialogue.tsx]

--- a/src/components/payroll-integration/grid.tsx
+++ b/src/components/payroll-integration/grid.tsx
@@ -43,7 +43,7 @@ const PayrollIntegrationListGrid: React.FC<PayrollIntegrationListGridProps> = ({
   return (
     <div
       className={cn(
-        'subi-connect sc-relative sc-grid sc-w-full sc-grid-cols-[repeat(auto-fill,_minmax(20rem,1fr))] sc-gap-4',
+        'sc-relative sc-grid sc-w-full sc-grid-cols-[repeat(auto-fill,_minmax(20rem,1fr))] sc-gap-4',
         containerClassName,
       )}
     >

--- a/src/pages/employee-management/index.tsx
+++ b/src/pages/employee-management/index.tsx
@@ -86,7 +86,7 @@ const EmployeeManagementPage: React.FC<{
   return (
     <div
       className={cn(
-        'subi-connect sc-flex sc-h-full sc-w-full sc-flex-col sc-gap-4 sc-p-4',
+        'sc-flex sc-h-full sc-w-full sc-flex-col sc-gap-4 sc-p-4',
         className,
       )}
     >

--- a/src/pages/payroll-integration-management/index.tsx
+++ b/src/pages/payroll-integration-management/index.tsx
@@ -118,7 +118,7 @@ const PayrollIntegrationManagementPage: React.FC<{
     return (
       <div
         className={cn(
-          'subi-connect sc-flex sc-h-full sc-w-full sc-flex-col sc-gap-4 sc-p-4',
+          'sc-flex sc-h-full sc-w-full sc-flex-col sc-gap-4 sc-p-4',
           className,
         )}
       >
@@ -140,7 +140,7 @@ const PayrollIntegrationManagementPage: React.FC<{
       <PayrollIntegrationProvider>
         <div
           className={cn(
-            'subi-connect sc-flex sc-h-full sc-w-full sc-flex-col sc-gap-4 sc-p-4',
+            'sc-flex sc-h-full sc-w-full sc-flex-col sc-gap-4 sc-p-4',
             className,
           )}
         >

--- a/src/pages/payroll-integrations/index.tsx
+++ b/src/pages/payroll-integrations/index.tsx
@@ -48,7 +48,7 @@ const PayrollIntegrationsPage: React.FC<{ className?: string }> = ({
   return (
     <div
       className={cn(
-        'subi-connect sc-flex sc-h-full sc-w-full sc-flex-col sc-gap-4 sc-p-4',
+        'sc-flex sc-h-full sc-w-full sc-flex-col sc-gap-4 sc-p-4',
         className,
       )}
     >

--- a/src/stories/wrapper.tsx
+++ b/src/stories/wrapper.tsx
@@ -33,9 +33,7 @@ export const withSubiConnectProvider = <T extends object>(
   const WrappedComponent = (props: T) => (
     <QueryClientProvider client={queryClient}>
       <SubiConnectProvider connectionFn={connectionFn}>
-        <div className='subi-connect'>
-          <Component {...props} />
-        </div>
+        <Component {...props} />
       </SubiConnectProvider>
     </QueryClientProvider>
   );

--- a/src/ui/data-table.tsx
+++ b/src/ui/data-table.tsx
@@ -68,7 +68,7 @@ export function DataTable<TData, TValue>({
   }
 
   return (
-    <div className='subi-connect sc-flex sc-flex-col sc-gap-2'>
+    <div className='sc-flex sc-flex-col sc-gap-2'>
       <DataTableToolbar table={table} {...toolbarProps} />
       <div className='sc-rounded-md sc-border'>
         <Table>


### PR DESCRIPTION
### TL;DR

Removed 'subi-connect' class from components inside the provider div container.

### What changed?

- The 'subi-connect' class has been removed from various components and pages.
- It is now only applied to the provider div container in '@src/context/subi-connect.tsx' and the dialogue component in '@src/ui/dialogue.tsx'.
- Updated class names in multiple files to remove the 'subi-connect' class.

### How to test?

1. Check the rendered HTML of affected components to ensure the 'subi-connect' class is not present.
2. Verify that the provider div container and dialogue component still have the 'subi-connect' class.
3. Ensure that the styling and layout of the components remain intact after the class removal.

### Why make this change?

This change aims to improve the specificity of the 'subi-connect' class usage. By limiting its application to only the provider div container and dialogue component, we can better control the scope of any styles associated with this class. This change helps prevent unintended style inheritance and makes the codebase more maintainable.