### PR TITLE
chore (workflows): change deploy-all-demos trigger to a created release (from published)

### DIFF
--- a/.github/workflows/deploy-all-demos.yml
+++ b/.github/workflows/deploy-all-demos.yml
@@ -3,7 +3,7 @@ name: Deploy Demos to All Environments
 on:
   workflow_dispatch:
   release:
-    types: [published]
+    types: [created]
 
 jobs:
   deploy-all:


### PR DESCRIPTION
### TL;DR

Updated the trigger for the "Deploy Demos to All Environments" workflow.

### What changed?

Modified the release event type that triggers the workflow from "published" to "created".

### How to test?

1. Create a new release in the repository.
2. Verify that the "Deploy Demos to All Environments" workflow is triggered automatically.
3. Ensure that the workflow runs successfully and deploys the demos as expected.

### Why make this change?

This change allows the deployment process to start earlier in the release cycle. By triggering the workflow when a release is created rather than when it's published, we can potentially catch and address any deployment issues sooner, improving the overall release process efficiency.