### PR TITLE
feat: add friendlyName to the account payroll system

### DIFF
--- a/.changeset/fair-apples-remember.md
+++ b/.changeset/fair-apples-remember.md
@@ -1,0 +1,10 @@
+---
+'@subifinancial/subi-connect': patch
+---
+
+Introduced a new getPayrollFriendlyName function to display user-friendly payroll system names throughout the application.
+
+- Added a `getPayrollFriendlyName` utility function in `src/lib/utils.ts`
+- Updated various components to use the new function for displaying payroll system names
+- Added a `friendlyName` property to the `AccountPayrollSystemExtended` type
+- Replaced direct references to `payrollSystem.name` with `getPayrollFriendlyName(payrollSystem)`

--- a/src/components/connect-and-integrate/index.tsx
+++ b/src/components/connect-and-integrate/index.tsx
@@ -1,6 +1,7 @@
 import { usePayrollIntegrationContext } from '../../context/payroll-integration';
 import { CustomPayrollIntegrationWorkflow } from '../../integration-pages/custom';
 import { usePostConnectPayroll } from '../../integration-pages/custom/mutation';
+import { getPayrollFriendlyName } from '../../lib/utils';
 import {
   type ConnectPayrollResponse,
   PayrollConnectionTypeEnum,
@@ -148,7 +149,7 @@ const Integrate: React.FC<{
         className='sc-flex sc-h-auto sc-max-h-[80%] sc-w-10/12 sc-max-w-xl sc-flex-col sc-overflow-y-auto md:sc-max-w-4xl'
       >
         <DialogueTitle className='sc-sr-only'>
-          Connect and Integrate {payrollSystem.name}
+          Connect and Integrate {getPayrollFriendlyName(payrollSystem)}
         </DialogueTitle>
         <CustomPayrollIntegrationWorkflow onSuccess={handleWorkflowOnSuccess} />
       </DialogueContent>

--- a/src/components/payroll-integration/card/base-card.tsx
+++ b/src/components/payroll-integration/card/base-card.tsx
@@ -1,4 +1,8 @@
-import { cn, getPayrollBannerImgUrl } from '../../../lib/utils';
+import {
+  cn,
+  getPayrollBannerImgUrl,
+  getPayrollFriendlyName,
+} from '../../../lib/utils';
 import { usePayrollSystemContext } from '../context';
 import React from 'react';
 
@@ -25,7 +29,7 @@ export const BaseCard: React.FC<CardProps> = ({
         style={{ backgroundColor: payrollSystem.backgroundColour }}
       >
         <img
-          alt={`${payrollSystem.name} Logo`}
+          alt={`${getPayrollFriendlyName(payrollSystem)} Logo`}
           src={bannerSrc}
           className='sc-h-full sc-w-full sc-object-contain'
           draggable={false}
@@ -36,7 +40,7 @@ export const BaseCard: React.FC<CardProps> = ({
       <div className='sc-flex sc-h-full sc-flex-col sc-justify-between sc-gap-2 sc-p-4'>
         <div className='sc-flex sc-flex-col sc-gap-2'>
           <h2 className='sc-font-mainMedium sc-text-2xl sc-text-secondary'>
-            {payrollSystem.name}
+            {getPayrollFriendlyName(payrollSystem)}
           </h2>
           {description}
         </div>

--- a/src/components/payroll-integration/card/variants/coming-soon.tsx
+++ b/src/components/payroll-integration/card/variants/coming-soon.tsx
@@ -1,4 +1,5 @@
 import { useCompany } from '../../../../hooks/use-company';
+import { getPayrollFriendlyName } from '../../../../lib/utils';
 import { Button } from '../../../../ui/button';
 import { Skeleton } from '../../../../ui/skeleton';
 import { usePayrollSystemContext } from '../../context';
@@ -40,9 +41,11 @@ export const ComingSoonCard = () => {
     description = (
       <p className='sc-font-light'>
         We are currently working on integrating{' '}
-        <span className='sc-font-mainMedium'>{payrollSystem.name}</span> with{' '}
-        <span className='sc-font-mainMedium'>{company.account.name}</span>. Once
-        enabledm you will be able to automatically add employees to your
+        <span className='sc-font-mainMedium'>
+          {getPayrollFriendlyName(payrollSystem)}
+        </span>{' '}
+        with <span className='sc-font-mainMedium'>{company.account.name}</span>.
+        Once enabledm you will be able to automatically add employees to your
         account.
       </p>
     );

--- a/src/components/payroll-integration/card/variants/connect.tsx
+++ b/src/components/payroll-integration/card/variants/connect.tsx
@@ -1,4 +1,5 @@
 import { useCompany } from '../../../../hooks/use-company';
+import { getPayrollFriendlyName } from '../../../../lib/utils';
 import { Button } from '../../../../ui/button';
 import { Skeleton } from '../../../../ui/skeleton';
 import Integrate from '../../../connect-and-integrate';
@@ -51,7 +52,10 @@ export const ConnectCard: React.FC = () => {
   } else {
     description = (
       <p className='sc-font-light'>
-        Connect <span className='sc-font-mainMedium'>{payrollSystem.name}</span>{' '}
+        Connect{' '}
+        <span className='sc-font-mainMedium'>
+          {getPayrollFriendlyName(payrollSystem)}
+        </span>{' '}
         to automatically add employees to your{' '}
         <span className='sc-font-mainMedium'>{company?.account.name}</span>{' '}
         account.

--- a/src/components/payroll-integration/card/variants/connected.tsx
+++ b/src/components/payroll-integration/card/variants/connected.tsx
@@ -1,5 +1,6 @@
 import useSearchParams from '../../../../hooks/internal/use-serach-params';
 import { useCompany } from '../../../../hooks/use-company';
+import { getPayrollFriendlyName } from '../../../../lib/utils';
 import { SearchParam } from '../../../../types/query';
 import { Button } from '../../../../ui/button';
 import { Skeleton } from '../../../../ui/skeleton';
@@ -46,7 +47,10 @@ export const ConnectedCard = () => {
     description = (
       <p className='sc-font-light'>
         You have successfully connected{' '}
-        <span className='sc-font-mainMedium'>{payrollSystem.name}</span> to your{' '}
+        <span className='sc-font-mainMedium'>
+          {getPayrollFriendlyName(payrollSystem)}
+        </span>{' '}
+        to your{' '}
         <span className='sc-font-mainMedium'>{company?.account.name}</span>{' '}
         account.
       </p>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,3 +1,4 @@
+import type { AccountPayrollSystemExtended } from '../types/application';
 import type { Payroll } from '../types/payroll';
 import { clsx, type ClassValue } from 'clsx';
 import { extendTailwindMerge } from 'tailwind-merge';
@@ -47,4 +48,10 @@ export const createNestedObjectFromString = <T>(
     .reduceRight<
       Record<string, unknown>
     >((acc, keyPart) => ({ [keyPart]: acc }), value as unknown as Record<string, unknown>);
+};
+
+export const getPayrollFriendlyName = (
+  application: AccountPayrollSystemExtended,
+) => {
+  return application.friendlyName ?? application.name;
 };

--- a/src/pages/payroll-integration-management/index.tsx
+++ b/src/pages/payroll-integration-management/index.tsx
@@ -8,7 +8,7 @@ import { PayrollIntegrationProvider } from '../../context/payroll-integration';
 import useSearchParams from '../../hooks/internal/use-serach-params';
 import { useAccountPayrollSystem } from '../../hooks/use-account-payroll';
 import { BASE_ORGANISATION_QUERY_KEY } from '../../hooks/use-organisations';
-import { cn } from '../../lib/utils';
+import { cn, getPayrollFriendlyName } from '../../lib/utils';
 import type { AccountPayrollSystemExtended } from '../../types/application';
 import type { Payroll } from '../../types/payroll';
 import { SearchParam } from '../../types/query';
@@ -90,7 +90,7 @@ const Header: React.FC<{
           <Skeleton className='sc-h-4 sc-w-10' />
         ) : (
           <span className='sc-font-mainMedium sc-text-xs sc-text-secondary/50'>
-            {accountPayroll.name}
+            {getPayrollFriendlyName(accountPayroll)}
           </span>
         )}
       </div>

--- a/src/types/application.ts
+++ b/src/types/application.ts
@@ -8,6 +8,9 @@ export type AccountPayrollSystemExtended = {
   /** The name of the payroll system. */
   name: Payroll;
 
+  /** The friendly name of the payroll system. */
+  friendlyName?: string;
+
   /** The payroll system logo. */
   bannerImg?: string;
 


### PR DESCRIPTION
### TL;DR

Introduced a new `getPayrollFriendlyName` function to display user-friendly payroll system names throughout the application.

### What changed?

- Added a `getPayrollFriendlyName` utility function in `src/lib/utils.ts`
- Updated various components to use the new function for displaying payroll system names
- Added a `friendlyName` property to the `AccountPayrollSystemExtended` type
- Replaced direct references to `payrollSystem.name` with `getPayrollFriendlyName(payrollSystem)`

### How to test?

1. Navigate to the payroll integration management page
2. Verify that payroll system names are displayed correctly, using friendly names where available
3. Check the connect, coming soon, and connected card variants to ensure they display the correct payroll system names
4. Test the integration workflow to confirm the dialogue title shows the friendly name

### Why make this change?

This change improves the user experience by displaying more user-friendly names for payroll systems throughout the application. It allows for flexibility in how payroll systems are presented to users, potentially using more recognizable or branded names while maintaining the original system identifiers internally.