### PR TITLE
chore (workflows): update deploy all demos to run on version changes

### DIFF
--- a/.github/workflows/deploy-all-demos.yml
+++ b/.github/workflows/deploy-all-demos.yml
@@ -2,8 +2,8 @@ name: Deploy Demos to All Environments
 
 on:
   workflow_dispatch:
-  release:
-    types: [created]
+  push:
+    tags: ['v*.*.*']
 
 jobs:
   deploy-all:


### PR DESCRIPTION
### TL;DR

Updated the trigger for the "Deploy Demos to All Environments" workflow.

### What changed?

The workflow trigger has been modified from responding to release creation events to now triggering on push events for version tags. Specifically:
- Removed the `release` trigger and its `types: [created]` condition
- Added a `push` trigger with `tags: ['v*.*.*']` condition

### How to test?

1. Create and push a new version tag (e.g., `v1.0.0`) to the repository
2. Verify that the "Deploy Demos to All Environments" workflow is triggered automatically
3. Ensure that creating a new release without pushing a tag does not trigger the workflow

### Why make this change?

This change allows for more precise control over when the deployment workflow runs. By triggering on version tags instead of release creation, it ensures that deployments are tied directly to specific versions in the codebase, potentially streamlining the release and deployment process.