### PR TITLE
fix: move from atob to hex encode

### DIFF
--- a/src/services/axios/connection-service.ts
+++ b/src/services/axios/connection-service.ts
@@ -51,12 +51,13 @@ export default class ConnectionService {
       this.context = DEFAULT_CONTEXT;
       return this;
     }
-    this.context = atob(plainContext);
+
+    this.context = this.hexEncodeContext(plainContext);
     return this;
   }
 
   public getContext() {
-    return btoa(this.context);
+    return this.hexDecodeContext(this.context);
   }
 
   public async generateAccessToken(): Promise<string> {
@@ -78,9 +79,17 @@ export default class ConnectionService {
     return this;
   }
 
-  reset() {
+  public reset() {
     this.context = DEFAULT_CONTEXT;
     this.connectionFn = null;
     return this;
+  }
+
+  private hexEncodeContext(context: string) {
+    return Buffer.from(context).toString('hex');
+  }
+
+  private hexDecodeContext(encodedContext: string) {
+    return Buffer.from(encodedContext, 'hex').toString('utf-8');
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR modifies the `ConnectionService` class to use hexadecimal encoding and decoding for the context instead of base64. It introduces two new private methods, `hexEncodeContext` and `hexDecodeContext`, to handle the conversion between plain text and hexadecimal representation.

#### What problem is this solving?

The change from base64 to hexadecimal encoding provides a more consistent and reliable way to handle the context data, especially when dealing with binary data or special characters. This approach reduces the likelihood of encoding-related issues and improves overall data integrity.

#### Types of changes

- [x] Feat: (new functionality)
- [ ] Bug fix: ([#ref number] non-breaking change which fixes an issue)
- [ ] Chore: (improvements that will not reflect in production behaviour)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.