### PR TITLE
fix: add error boundary for hooks

### DIFF
--- a/.changeset/few-boats-share.md
+++ b/.changeset/few-boats-share.md
@@ -1,0 +1,5 @@
+---
+'@subifinancial/subi-connect': patch
+---
+
+Wrap queries and mutations in a Subi Connect wrapper to throw an error when used outside of the Subi Connect context.

--- a/src/context/subi-connect.tsx
+++ b/src/context/subi-connect.tsx
@@ -22,7 +22,7 @@ export const useSubiConnectContext = (): SubiConnectContext => {
   const context = React.useContext(SubiConnectContext);
   if (!context) {
     throw new Error(
-      'useSubiConnectContext must be used within a SubiConnectProvider',
+      'Subi Connect hooks must be used within a SubiConnectProvider',
     );
   }
   return context;

--- a/src/hooks/internal/use-query-params.ts
+++ b/src/hooks/internal/use-query-params.ts
@@ -16,7 +16,7 @@ const useQueryParam = (
   defaultVal: string,
 ): [string, (val: string) => void] => {
   const [query, setQuery] = React.useState(
-    getQueryStringVal(key) || defaultVal,
+    getQueryStringVal(key) ?? defaultVal,
   );
 
   const updateUrl = (newVal: string) => {

--- a/src/hooks/use-account-payroll.tsx
+++ b/src/hooks/use-account-payroll.tsx
@@ -3,7 +3,8 @@ import type { AccountPayrollSystemExtended } from '../types/application';
 import type { Payroll } from '../types/payroll';
 import type { BaseQueryOptions } from '../types/query';
 import { BASE_PAYROLL_APPLICATION_QUERY_KEY } from './use-payroll-systems';
-import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+import { useSubiConnectQuery } from './use-subi-connect-query';
+import type { UseQueryOptions } from '@tanstack/react-query';
 import React from 'react';
 
 type UsePayrollSystemsOptions = {
@@ -26,7 +27,7 @@ export const useAccountPayrollSystem = (
     [payroll],
   );
 
-  return useQuery({
+  return useSubiConnectQuery({
     queryKey: queryKey,
     queryFn: queryFn,
     ...options?.queryOptions,

--- a/src/hooks/use-company.tsx
+++ b/src/hooks/use-company.tsx
@@ -5,7 +5,8 @@ import {
 import type { Payroll } from '../types';
 import type { Company } from '../types/company';
 import type { BaseQueryOptions } from '../types/query';
-import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+import { useSubiConnectQuery } from './use-subi-connect-query';
+import { type UseQueryOptions } from '@tanstack/react-query';
 
 const BASE_COMPANY_QUERY_KEY = ['subi-connect', 'company'] as const;
 
@@ -19,7 +20,7 @@ export const useCompany = (options?: UseCompanyOptions) => {
    * one company in the context
    */
   const queryKey = [...BASE_COMPANY_QUERY_KEY, 'detail'] as const;
-  return useQuery({
+  return useSubiConnectQuery({
     queryKey: queryKey,
     queryFn: getCompany,
     ...options?.queryOptions,
@@ -39,7 +40,7 @@ export const useCompanyPayrollIntegrations = (
   options?: UseCompanyPayrollIntegrationsOptions,
 ) => {
   const queryKey = [...BASE_COMPANY_PAYROLL_INTEGRATIONS_QUERY_KEY] as const;
-  return useQuery({
+  return useSubiConnectQuery({
     queryKey: queryKey,
     queryFn: getCompanyPayrollIntegrations,
     ...options?.queryOptions,

--- a/src/hooks/use-connected-payrolls.tsx
+++ b/src/hooks/use-connected-payrolls.tsx
@@ -4,7 +4,8 @@ import type { PaginationResponse } from '../types/components/data-table';
 import type { BaseQueryOptions } from '../types/query';
 import { useCompany } from './use-company';
 import { BASE_PAYROLL_APPLICATION_QUERY_KEY } from './use-payroll-systems';
-import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+import { useSubiConnectQuery } from './use-subi-connect-query';
+import { type UseQueryOptions } from '@tanstack/react-query';
 import React from 'react';
 
 type UseConnectedPayrollsOptions = {
@@ -27,7 +28,7 @@ export const useConnectedPayrolls = (options?: UseConnectedPayrollsOptions) => {
 
   const { enabled, ...rest } = options?.queryOptions ?? { enabled: true };
 
-  return useQuery({
+  return useSubiConnectQuery({
     queryKey: queryKey,
     queryFn: listConnectedPayrollSystems,
     enabled: !!company?.id && enabled,

--- a/src/hooks/use-employees.tsx
+++ b/src/hooks/use-employees.tsx
@@ -7,7 +7,8 @@ import type {
 import type { Employee, SelectableEmployeeColumns } from '../types/employee';
 import type { BaseQueryOptions } from '../types/query';
 import type { DeepPartial } from '../types/utils';
-import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+import { useSubiConnectQuery } from './use-subi-connect-query';
+import { type UseQueryOptions } from '@tanstack/react-query';
 import React from 'react';
 
 const BASE_EMPLOYEES_QUERY_KEY = ['subi-connect', 'employee'] as const;
@@ -45,7 +46,7 @@ export const useEmployees = (options?: UseEmployeesOptions) => {
     [options?.listOptions, params],
   );
 
-  return useQuery({
+  return useSubiConnectQuery({
     queryKey: queryKey,
     queryFn: queryFn,
     ...options?.queryOptions,

--- a/src/hooks/use-organisations.tsx
+++ b/src/hooks/use-organisations.tsx
@@ -14,7 +14,8 @@ import type {
 } from '../types/components/data-table';
 import type { Organisation } from '../types/organisation';
 import type { BaseQueryOptions } from '../types/query';
-import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+import { useSubiConnectQuery } from './use-subi-connect-query';
+import { type UseQueryOptions } from '@tanstack/react-query';
 import React from 'react';
 
 export const BASE_ORGANISATION_QUERY_KEY = [
@@ -69,7 +70,7 @@ export const useOrganisations = (
     enabled: true,
   };
 
-  return useQuery({
+  return useSubiConnectQuery({
     queryKey: queryKey,
     queryFn: queryFn,
     enabled: !!accountPayrollId && enabled,
@@ -109,7 +110,7 @@ export const useAllOrganisations = (options?: UseAllOrganisationsOptions) => {
     [options?.listOptions, params],
   );
 
-  return useQuery({
+  return useSubiConnectQuery({
     queryKey: queryKey,
     queryFn: queryFn,
     ...options?.queryOptions,
@@ -131,7 +132,7 @@ const useSyncingOrganisationsQueryKey = [
 export const useSyncingOrganisations = (
   options?: UseSyncingOrganisationsOptions,
 ) => {
-  return useQuery({
+  return useSubiConnectQuery({
     queryKey: useSyncingOrganisationsQueryKey,
     queryFn: listSyncingOrganisations,
     ...options?.queryOptions,
@@ -161,7 +162,7 @@ export const useOrganisation = (
     enabled: true,
   };
 
-  return useQuery({
+  return useSubiConnectQuery({
     queryKey: queryKey,
     queryFn: queryFn,
     enabled: !!organisationId && enabled,

--- a/src/hooks/use-payroll-systems.tsx
+++ b/src/hooks/use-payroll-systems.tsx
@@ -5,7 +5,8 @@ import type {
   PaginationResponse,
 } from '../types/components/data-table';
 import type { BaseQueryOptions } from '../types/query';
-import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+import { useSubiConnectQuery } from './use-subi-connect-query';
+import { type UseQueryOptions } from '@tanstack/react-query';
 import React from 'react';
 
 export const BASE_PAYROLL_APPLICATION_QUERY_KEY = [
@@ -49,7 +50,7 @@ export const usePayrollSystems = (options?: UsePayrollSystemsOptions) => {
     [options?.listOptions, params],
   );
 
-  return useQuery({
+  return useSubiConnectQuery({
     queryKey: queryKey,
     queryFn: queryFn,
     ...options?.queryOptions,

--- a/src/hooks/use-subi-connect-query.ts
+++ b/src/hooks/use-subi-connect-query.ts
@@ -1,0 +1,28 @@
+import { useSubiConnectContext } from '@/context/subi-connect';
+import {
+  useQuery,
+  useMutation,
+  type UseQueryOptions,
+  type UseMutationOptions,
+  type QueryKey,
+} from '@tanstack/react-query';
+
+export function useSubiConnectQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>(options: UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>) {
+  useSubiConnectContext();
+  return useQuery(options);
+}
+
+export function useSubiConnectMutation<
+  TData = unknown,
+  TError = unknown,
+  TVariables = void,
+  TContext = unknown,
+>(options: UseMutationOptions<TData, TError, TVariables, TContext>) {
+  useSubiConnectContext();
+  return useMutation(options);
+}

--- a/src/integration-pages/custom/mutation.tsx
+++ b/src/integration-pages/custom/mutation.tsx
@@ -1,9 +1,9 @@
+import { useSubiConnectMutation } from '@/hooks/use-subi-connect-query';
 import {
   connectPayroll,
   integratePayroll,
 } from '@/services/api/payroll/actions';
 import type { Payroll } from '@/types/payroll';
-import { useMutation } from '@tanstack/react-query';
 import type { AxiosRequestConfig } from 'axios';
 
 type PostPayrollIntegration = {
@@ -16,7 +16,7 @@ export type UsePostPayrollIntegrationProps = {
 };
 
 export const usePostPayrollIntegration = () => {
-  return useMutation({
+  return useSubiConnectMutation({
     mutationFn: ({
       payrollSystem,
       integrationParams,
@@ -34,7 +34,7 @@ export type UsePostConnectPayrollProps = {
 };
 
 export const usePostConnectPayroll = () => {
-  return useMutation({
+  return useSubiConnectMutation({
     mutationFn: ({ payroll }: UsePostConnectPayrollProps) => {
       return connectPayroll({
         payroll,


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR introduces a wrapper for queries and mutations in Subi Connect to ensure they are used within the correct context. It also updates various hooks to use this new wrapper.

#### What problem is this solving?

This change enhances error handling by throwing a specific error when Subi Connect hooks are used outside of the SubiConnectProvider context. It improves the developer experience by providing clearer error messages and enforcing proper usage of the Subi Connect library.

#### Types of changes

- [x] Feat: (new functionality)
- [ ] Bug fix: ([#ref number] non-breaking change which fixes an issue)
- [x] Chore: (improvements that will not reflect in production behaviour)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.