### PR TITLE
feat: add companyContext prop to SubiConnectProvider

### DIFF
--- a/.changeset/two-socks-float.md
+++ b/.changeset/two-socks-float.md
@@ -1,0 +1,30 @@
+---
+'@subifinancial/subi-connect': major
+---
+
+# Breaking Changes
+
+- The `SubiConnectProvider` now requires a `companyContext` prop, which is a string that uniquely identifies the organization (e.g., company ID or name).
+- Removed the `context` option from `SubiConnectOptions`.
+
+# New Features
+
+- Added type safety for the `companyContext` prop in `SubiConnectProvider`.
+
+# Improvements
+
+- Updated the `ACCESS_TOKEN_NAME` constant to use a shorter name: 'sc-cat'.
+- Enhanced the `ConnectionService` to handle context changes and update stored access tokens accordingly.
+- Improved type definitions for the connection function and related types.
+
+# Internal Changes
+
+- Updated demos, stories, and examples to use the new `companyContext` prop.
+- Refactored `ConnectionService` to use the new `companyContext` approach.
+- Updated `getAccessToken` function to use the new `SubiConnectConnectionFn` type.
+
+# Documentation
+
+- Added comments to `SubiConnectContext` and `SubiConnectProviderProps` for better documentation.
+
+This major version change requires users to update their `SubiConnectProvider` usage by adding the `companyContext` prop and removing any `context` option from `SubiConnectOptions`.

--- a/.github/workflows/deploy-all-demos.yml
+++ b/.github/workflows/deploy-all-demos.yml
@@ -14,4 +14,3 @@ jobs:
     uses: ./.github/workflows/deploy-demo.yml
     with:
       env: ${{ matrix.env }}
-    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -72,7 +72,12 @@ function App() {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <SubiConnectProvider connectionFn={connectionFn}>...</SubiConnectProvider>
+      <SubiConnectProvider
+        connectionFn={connectionFn}
+        companyContext={company.referenceId}
+      >
+        ...
+      </SubiConnectProvider>
     </QueryClientProvider>
   );
 }

--- a/demo/world-pay/package-lock.json
+++ b/demo/world-pay/package-lock.json
@@ -43,7 +43,7 @@
       }
     },
     ".yalc/@subifinancial/subi-connect": {
-      "version": "1.5.6+b3d9f22c",
+      "version": "2.0.1+3f9388c2",
       "license": "MIT",
       "dependencies": {
         "@mdx-js/mdx": "^3.0.1",

--- a/demo/world-pay/src/components/extended/code-block.tsx
+++ b/demo/world-pay/src/components/extended/code-block.tsx
@@ -33,7 +33,10 @@ const SubiConnectProviderWrapper = ({
   children: React.ReactNode;
 }) => {
   return (
-    <SubiConnectProvider connectionFn={connectionFn}>
+    <SubiConnectProvider
+      connectionFn={connectionFn}
+      companyContext='world-pay-demo-referenceId-1'
+    >
       {children}
     </SubiConnectProvider>
   );
@@ -58,7 +61,10 @@ const SubiConnectProviderWrapper = ({
   }, [company]);
 
   return (
-    <SubiConnectProvider connectionFn={completeConnectionFn}>
+    <SubiConnectProvider
+      connectionFn={completeConnectionFn}
+      companyContext={company.referenceId}
+    >
       {children}
     </SubiConnectProvider>
   );

--- a/demo/world-pay/src/context/subi-connect-wrapper.tsx
+++ b/demo/world-pay/src/context/subi-connect-wrapper.tsx
@@ -17,7 +17,10 @@ const SubiConnectProviderWrapper = ({
   }, [apiKey]);
 
   return (
-    <SubiConnectProvider connectionFn={completeConnectionFn}>
+    <SubiConnectProvider
+      connectionFn={completeConnectionFn}
+      companyContext="worldpay-demo-referenceId-1"
+    >
       {children}
     </SubiConnectProvider>
   );

--- a/src/components/payroll-integration/live.stories.tsx
+++ b/src/components/payroll-integration/live.stories.tsx
@@ -11,7 +11,6 @@ const connectionFn = async () => {
   const result = await axios.post(
     `${process.env.SUBI_CONNECT_PUBLIC_BASE_URL}authentication/company-access-token`,
     {
-      // company: { referenceId: 'abc', name: 'sample company' }
       company: {
         referenceId: 'world-pay-demo-referenceId-1',
         name: 'Demo Company',
@@ -29,7 +28,10 @@ const connectionFn = async () => {
 const Component = ({ error }: { error?: React.ReactNode }) => {
   return (
     <QueryClientProvider client={queryClient}>
-      <SubiConnectProvider connectionFn={connectionFn}>
+      <SubiConnectProvider
+        connectionFn={connectionFn}
+        companyContext='storybooks-demo-referenceId-1'
+      >
         <PayrollIntegrationList error={error} />
       </SubiConnectProvider>
     </QueryClientProvider>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,3 @@
-export const ACCESS_TOKEN_NAME = 'subi-connect-client-access-token';
+export const ACCESS_TOKEN_NAME = 'sc-cat';
 
 export const DATE_FORMAT = 'dd/MM/yyyy hh:mm aa';

--- a/src/services/axios/utils/get-token.ts
+++ b/src/services/axios/utils/get-token.ts
@@ -1,11 +1,14 @@
 import logger from '@/services/logger';
-import type { SubiConnectAccessToken } from '@/types/main';
+import type {
+  SubiConnectAccessToken,
+  SubiConnectConnectionFn,
+} from '@/types/main';
 
 /**
  * Function to handle token retrieval.
  */
 export const getAccessToken = async (
-  connectionFn: () => Promise<SubiConnectAccessToken>,
+  connectionFn: SubiConnectConnectionFn,
 ): Promise<SubiConnectAccessToken | null> => {
   try {
     return await connectionFn();

--- a/src/stories/wrapper.tsx
+++ b/src/stories/wrapper.tsx
@@ -32,7 +32,10 @@ export const withSubiConnectProvider = <T extends object>(
 ) => {
   const WrappedComponent = (props: T) => (
     <QueryClientProvider client={queryClient}>
-      <SubiConnectProvider connectionFn={connectionFn}>
+      <SubiConnectProvider
+        connectionFn={connectionFn}
+        companyContext='storybooks-demo-referenceId-1'
+      >
         <Component {...props} />
       </SubiConnectProvider>
     </QueryClientProvider>

--- a/src/types/main.ts
+++ b/src/types/main.ts
@@ -1,5 +1,7 @@
 export type SubiConnectAccessToken = string;
 
+export type SubiConnectConnectionFn = () => Promise<SubiConnectAccessToken>;
+
 export type SubiConnectDebugOptions = {
   /**
    * Sets the base URL for the SubiConnect API.
@@ -30,12 +32,6 @@ export type SubiConnectOptions = {
    * initialisation process to complete before rendering the children.
    */
   bypassInitialisation?: boolean;
-
-  /**
-   * The context for the SubiConnect API. This can be something that uniquely
-   * identifies the organisation—for example, the company ID or name.
-   */
-  context?: string;
 };
 
 export enum SyncStatus {


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR introduces a major version change to the `@subifinancial/subi-connect` package, focusing on improving the handling of company context and enhancing type safety.

#### What problem is this solving?

The changes address the need for a more robust and type-safe way to handle company-specific contexts in the SubiConnect provider. It also simplifies the API by removing redundant options and improving the overall structure of the connection service.

#### Types of changes

- [x] Feat: (new functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires change to documentation, which has been updated accordingly.

#### Breaking Changes

1. `SubiConnectProvider` now requires a `companyContext` prop.
2. Removed the `context` option from `SubiConnectOptions`.

#### New Features

1. Added type safety for the `companyContext` prop in `SubiConnectProvider`.

#### Improvements

1. Updated `ACCESS_TOKEN_NAME` constant to use a shorter name: 'sc-cat'.
2. Enhanced `ConnectionService` to handle context changes and update stored access tokens.
3. Improved type definitions for the connection function and related types.

#### Internal Changes

1. Updated demos, stories, and examples to use the new `companyContext` prop.
2. Refactored `ConnectionService` to use the new `companyContext` approach.
3. Updated `getAccessToken` function to use the new `SubiConnectConnectionFn` type.

#### Documentation

1. Added comments to `SubiConnectContext` and `SubiConnectProviderProps` for better documentation.

Users will need to update their `SubiConnectProvider` usage by adding the `companyContext` prop and removing any `context` option from `SubiConnectOptions`.