### PR TITLE
fix: encode context during access token context update

### DIFF
--- a/.changeset/grumpy-nails-end.md
+++ b/.changeset/grumpy-nails-end.md
@@ -1,0 +1,5 @@
+---
+'@subifinancial/subi-connect': patch
+---
+
+Fix `setContext` not encoding the context during access token context update.

--- a/src/services/axios/connection-service.ts
+++ b/src/services/axios/connection-service.ts
@@ -47,8 +47,12 @@ export default class ConnectionService {
   }
 
   public setContext(plainContext: string) {
-    this.updateAccessTokenContext(this.context, plainContext);
-    this.context = this.hexEncodeContext(plainContext);
+    const encodedContext = this.hexEncodeContext(plainContext);
+    this.updateAccessTokenContext({
+      oldContext: this.context,
+      newContext: encodedContext,
+    });
+    this.context = encodedContext;
     return this;
   }
 
@@ -75,7 +79,13 @@ export default class ConnectionService {
     return this;
   }
 
-  private updateAccessTokenContext(oldContext: string, newContext: string) {
+  private updateAccessTokenContext({
+    oldContext,
+    newContext,
+  }: {
+    oldContext: string;
+    newContext: string;
+  }) {
     const oldToken = localStorage.getItem(
       `${ACCESS_TOKEN_NAME}__${oldContext}`,
     );


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR fixes an issue with the `setContext` method in the `ConnectionService` class. It now properly encodes the context during the access token context update process.

#### What problem is this solving?

The previous implementation was not encoding the context when updating the access token context, which could lead to inconsistencies in context handling. This change ensures that the context is properly encoded before being used in the access token update.

#### Types of changes

- [x] Bug fix: (non-breaking change which fixes an issue)
- [ ] Feat: (new functionality)
- [ ] Chore: (improvements that will not reflect in production behaviour)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.