### PR TITLE
chore (demos): add https to localhost

### DIFF
--- a/demo/world-pay/package-lock.json
+++ b/demo/world-pay/package-lock.json
@@ -45,7 +45,7 @@
       }
     },
     ".yalc/@subifinancial/subi-connect": {
-      "version": "3.0.2+260ba936",
+      "version": "3.1.0+790febb5",
       "license": "MIT",
       "dependencies": {
         "@mdx-js/mdx": "^3.0.1",

--- a/demo/world-pay/vite.config.ts
+++ b/demo/world-pay/vite.config.ts
@@ -1,6 +1,13 @@
 import react from '@vitejs/plugin-react-swc';
+import dotenv from 'dotenv';
+import os from 'os';
 import path from 'path';
 import { defineConfig } from 'vite';
+
+dotenv.config();
+
+const key = process.env.VITE_KEY;
+const cert = process.env.VITE_CERT;
 
 export default defineConfig({
   plugins: [react()],
@@ -14,5 +21,13 @@ export default defineConfig({
   },
   server: {
     port: 3001,
+    ...(key && cert
+      ? {
+          https: {
+            key: `${os.homedir()}/${key}`,
+            cert: `${os.homedir()}/${cert}`,
+          },
+        }
+      : {}),
   },
 });


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR updates the `subi-connect` package to version 3.1.0 and enhances the Vite configuration to support HTTPS in development mode when environment variables for SSL certificates are provided.

#### What problem is this solving?

The update to `subi-connect` brings in the latest features and improvements. Additionally, the Vite configuration changes allow developers to run the application with HTTPS locally, which can be necessary for testing certain features or integrations that require secure connections.

#### Types of changes

- [x] Feat: (new functionality)
- [ ] Bug fix: ([#ref number] non-breaking change which fixes an issue)
- [x] Chore: (improvements that will not reflect in production behaviour)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.