### PR TITLE
feat: support multiple salaries and calendars for employees

### DIFF
--- a/.changeset/hip-garlics-tie.md
+++ b/.changeset/hip-garlics-tie.md
@@ -1,0 +1,63 @@
+---
+'@subifinancial/subi-connect': major
+---
+
+# Major Changes
+
+1. **Employee Table Columns Update:**
+   - Updated the employee table columns to support multiple calendars, salaries, and emails.
+   - Modified components to use new context providers for handling calendar and salary data.
+
+2. **Components Updated:**
+   - **`next-payment-date.tsx`**:
+     - Added `useCalendar` hook to manage selected calendar ID.
+     - Updated rendering logic to handle multiple calendars.
+   - **`paycycle.tsx`**:
+     - Added `useCalendar` hook to manage selected calendar ID.
+     - Updated rendering logic to handle multiple calendars.
+   - **`start-employment-date.tsx`**:
+     - Added `useCalendar` hook to manage selected calendar ID.
+     - Updated rendering logic to handle multiple calendars.
+   - **`hourly-rate.tsx`**:
+     - Added `useSalary` hook to manage selected salary ID.
+     - Updated rendering logic to handle multiple salaries.
+   - **`salary.tsx`**:
+     - Added `useSalary` hook to manage selected salary ID.
+     - Updated rendering logic to handle multiple salaries.
+   - **`core.tsx`**:
+     - Updated email column to handle multiple email addresses.
+   - **`consts.ts`**:
+     - Fixed typo in `startEmploymentDateColumn` export.
+   - **`index.tsx`**:
+     - Added `CalendarProvider` and `SalaryProvider` to manage context for calendar and salary data.
+     - Updated `EmployeesTable` component to use new context providers.
+
+3. **New Context Providers:**
+   - **`calendar-context.tsx`**:
+     - Created `CalendarProvider` and `useCalendar` hook to manage calendar-related state.
+   - **`salary-context.tsx`**:
+     - Created `SalaryProvider` and `useSalary` hook to manage salary-related state.
+
+4. **Storybook Updates:**
+   - **`live.stories.tsx`**:
+     - Added new stories for `PayCycle`, `NextPaymentDate`, `StartEmploymentDate`, `AllCalendars`, and `AllSalaries`.
+
+5. **Type Definitions Updated:**
+   - **`types.ts`**:
+     - Updated `Employee` type to support multiple emails, salaries, and calendars.
+     - Fixed typo in `SelectableEmployeeColumns`.
+
+6. **API Types Updated:**
+   - **`types.ts`**:
+     - Updated `EmployeeFilterFields` to include `email` as a required field.
+
+7. **Data Table Component Updated:**
+   - **`data-table.tsx`**:
+     - Added support for `rowContexts` to wrap table rows with context providers.
+
+8. **Employee Info Structure**: 
+  - `salary` field changed to `salaries` (array of `EmployeeSalary`).
+  - `calendar` field changed to `calendars` (array of `EmployeeCalendar`).
+  - `email` field changed to `emails` (array of strings).
+
+These changes introduce significant improvements to the handling of employee data, allowing for more flexible and robust management of multiple calendars, salaries, and emails.

--- a/demo/world-pay/package-lock.json
+++ b/demo/world-pay/package-lock.json
@@ -42,13 +42,10 @@
         "tailwindcss-animate": "^1.0.7",
         "typescript": "^5.2.2",
         "vite": "^5.2.0"
-      },
-      "devDependencies": {
-        "dotenv": "^16.4.5"
       }
     },
     ".yalc/@subifinancial/subi-connect": {
-      "version": "3.1.0+790febb5",
+      "version": "3.1.1+6c839657",
       "license": "MIT",
       "dependencies": {
         "@mdx-js/mdx": "^3.0.1",
@@ -3329,18 +3326,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.4.5",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/eastasianwidth": {

--- a/demo/world-pay/package.json
+++ b/demo/world-pay/package.json
@@ -45,8 +45,5 @@
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^5.2.2",
     "vite": "^5.2.0"
-  },
-  "devDependencies": {
-    "dotenv": "^16.4.5"
   }
 }

--- a/demo/world-pay/vite.config.ts
+++ b/demo/world-pay/vite.config.ts
@@ -1,33 +1,34 @@
 import react from '@vitejs/plugin-react-swc';
-import dotenv from 'dotenv';
 import os from 'os';
 import path from 'path';
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 
-dotenv.config();
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd());
 
-const key = process.env.VITE_KEY;
-const cert = process.env.VITE_CERT;
+  const key = env.VITE_KEY;
+  const cert = env.VITE_CERT;
 
-export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
+  return {
+    plugins: [react()],
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+      },
     },
-  },
-  css: {
-    postcss: './postcss.config.js',
-  },
-  server: {
-    port: 3001,
-    ...(key && cert
-      ? {
-          https: {
-            key: `${os.homedir()}/${key}`,
-            cert: `${os.homedir()}/${cert}`,
-          },
-        }
-      : {}),
-  },
+    css: {
+      postcss: './postcss.config.js',
+    },
+    server: {
+      port: 3001,
+      ...(key && cert
+        ? {
+            https: {
+              key: `${os.homedir()}/${key}`,
+              cert: `${os.homedir()}/${cert}`,
+            },
+          }
+        : {}),
+    },
+  };
 });

--- a/src/components/employees-table/columns/additional-fields/calendar/next-payment-date.tsx
+++ b/src/components/employees-table/columns/additional-fields/calendar/next-payment-date.tsx
@@ -1,24 +1,71 @@
+import { useCalendar } from '@/context/table/columns/calendars/calendar-context';
 import type { ColumnDef } from '@/types/components/data-table';
 import type { Employee } from '@/types/employee';
 import { DataTableColumnHeader } from '@/ui/data-table-column-header';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/ui/select';
 import type { CellContext } from '@tanstack/react-table';
 import React from 'react';
 
 const NextPaymentDateCell: React.FC<CellContext<Employee, unknown>> = ({
   row,
 }) => {
-  if (!row.original.info.calendar?.nextPaymentDate) return '';
+  const { selectedCalendarId, setSelectedCalendarId } = useCalendar();
 
-  const value = row.original.info?.calendar?.nextPaymentDate;
+  const id =
+    selectedCalendarId ?? row.original.info?.calendars?.[0]?.id?.toString();
 
-  return value;
+  React.useEffect(() => {
+    if (!selectedCalendarId) {
+      setSelectedCalendarId(row.original.info?.calendars?.[0]?.id?.toString());
+    }
+  }, [selectedCalendarId]);
+
+  if (!row.original.info.calendars || row.original.info.calendars.length === 0)
+    return '';
+
+  if (row.original.info.calendars.length === 1) {
+    if (!row.original.info.calendars[0]?.nextPaymentDate) return '';
+
+    if (!selectedCalendarId)
+      setSelectedCalendarId(row.original.info.calendars[0]!.id.toString());
+
+    return row.original.info.calendars[0]?.nextPaymentDate;
+  }
+
+  return (
+    <Select value={id} onValueChange={setSelectedCalendarId}>
+      <SelectTrigger>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {row.original.info.calendars.map((calendar) => {
+          if (!calendar.nextPaymentDate) return null;
+          return (
+            <SelectItem key={calendar.id} value={calendar.id.toString()}>
+              {calendar.nextPaymentDate}
+            </SelectItem>
+          );
+        })}
+      </SelectContent>
+    </Select>
+  );
 };
 
 export const nextPaymentDateColumn: ColumnDef<Employee> = {
   id: 'nextPaymentDate',
-  accessorKey: 'info.calendar.nextPaymentDate',
+  accessorKey: 'info.calendars',
   header: ({ column }) => (
-    <DataTableColumnHeader column={column} title={'Next Pay Day'} />
+    <DataTableColumnHeader
+      column={column}
+      title={'Next Pay Day'}
+      className='sc-w-[130px]'
+    />
   ),
   cell: NextPaymentDateCell,
 };

--- a/src/components/employees-table/columns/additional-fields/calendar/paycycle.tsx
+++ b/src/components/employees-table/columns/additional-fields/calendar/paycycle.tsx
@@ -1,20 +1,63 @@
+import { useCalendar } from '@/context/table/columns/calendars/calendar-context';
 import type { ColumnDef } from '@/types/components/data-table';
 import type { Employee } from '@/types/employee';
 import { DataTableColumnHeader } from '@/ui/data-table-column-header';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/ui/select';
 import type { CellContext } from '@tanstack/react-table';
 import React from 'react';
 
 const PayCycleCell: React.FC<CellContext<Employee, unknown>> = ({ row }) => {
-  if (!row.original.info?.calendar?.paycycle) return '';
+  const { selectedCalendarId, setSelectedCalendarId } = useCalendar();
 
-  const value = row.original.info?.calendar?.paycycle;
+  const id =
+    selectedCalendarId ?? row.original.info?.calendars?.[0]?.id?.toString();
 
-  return value;
+  React.useEffect(() => {
+    if (!selectedCalendarId) {
+      setSelectedCalendarId(row.original.info?.calendars?.[0]?.id?.toString());
+    }
+  }, [selectedCalendarId]);
+
+  if (!row.original.info.calendars || row.original.info.calendars.length === 0)
+    return '';
+
+  if (row.original.info.calendars.length === 1) {
+    if (!row.original.info.calendars[0]?.paycycle) return '';
+
+    if (!selectedCalendarId)
+      setSelectedCalendarId(row.original.info.calendars[0]!.id.toString());
+
+    return row.original.info.calendars[0]?.paycycle;
+  }
+
+  return (
+    <Select value={id} onValueChange={setSelectedCalendarId}>
+      <SelectTrigger>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {row.original.info.calendars.map((calendar) => {
+          if (!calendar.paycycle) return null;
+          return (
+            <SelectItem key={calendar.id} value={calendar.id.toString()}>
+              {calendar.paycycle}
+            </SelectItem>
+          );
+        })}
+      </SelectContent>
+    </Select>
+  );
 };
 
 export const payCycleColumn: ColumnDef<Employee> = {
   id: 'paycycle',
-  accessorKey: 'info.calendar.paycycle',
+  accessorKey: 'info.calendars',
   header: ({ column }) => (
     <DataTableColumnHeader column={column} title={'Pay Cycle'} />
   ),

--- a/src/components/employees-table/columns/additional-fields/calendar/start-employment-date.tsx
+++ b/src/components/employees-table/columns/additional-fields/calendar/start-employment-date.tsx
@@ -1,24 +1,71 @@
+import { useCalendar } from '@/context/table/columns/calendars/calendar-context';
 import type { ColumnDef } from '@/types/components/data-table';
 import type { Employee } from '@/types/employee';
 import { DataTableColumnHeader } from '@/ui/data-table-column-header';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/ui/select';
 import type { CellContext } from '@tanstack/react-table';
 import React from 'react';
 
 const StartEmploymentDateCell: React.FC<CellContext<Employee, unknown>> = ({
   row,
 }) => {
-  if (!row.original.info?.calendar?.startEmploymentDate) return '';
+  const { selectedCalendarId, setSelectedCalendarId } = useCalendar();
 
-  const value = row.original.info?.calendar?.startEmploymentDate;
+  const id =
+    selectedCalendarId ?? row.original.info?.calendars?.[0]?.id?.toString();
 
-  return value;
+  React.useEffect(() => {
+    if (!selectedCalendarId) {
+      setSelectedCalendarId(row.original.info?.calendars?.[0]?.id?.toString());
+    }
+  }, [selectedCalendarId]);
+
+  if (!row.original.info.calendars || row.original.info.calendars.length === 0)
+    return '';
+
+  if (row.original.info.calendars.length === 1) {
+    if (!row.original.info.calendars[0]?.startEmploymentDate) return '';
+
+    if (!selectedCalendarId)
+      setSelectedCalendarId(row.original.info.calendars[0]!.id.toString());
+
+    return row.original.info.calendars[0]?.startEmploymentDate;
+  }
+
+  return (
+    <Select value={id} onValueChange={setSelectedCalendarId}>
+      <SelectTrigger>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {row.original.info.calendars.map((calendar) => {
+          if (!calendar.startEmploymentDate) return null;
+          return (
+            <SelectItem key={calendar.id} value={calendar.id.toString()}>
+              {calendar.startEmploymentDate}
+            </SelectItem>
+          );
+        })}
+      </SelectContent>
+    </Select>
+  );
 };
 
-export const startEmployementDateColumn: ColumnDef<Employee> = {
+export const startEmploymentDateColumn: ColumnDef<Employee> = {
   id: 'startEmploymentDate',
-  accessorKey: 'info.calendar.startEmploymentDate',
+  accessorKey: 'info.calendars',
   header: ({ column }) => (
-    <DataTableColumnHeader column={column} title={'Start Date'} />
+    <DataTableColumnHeader
+      column={column}
+      title={'Start Date'}
+      className='sc-w-[130px]'
+    />
   ),
   cell: StartEmploymentDateCell,
 };

--- a/src/components/employees-table/columns/additional-fields/hourly-rate.tsx
+++ b/src/components/employees-table/columns/additional-fields/hourly-rate.tsx
@@ -1,21 +1,73 @@
+import { useSalary } from '@/context/table/columns/salaries/salary-context';
 import { getMoneyFromDecimals } from '@/lib/utils';
 import type { ColumnDef } from '@/types/components/data-table';
-import type { Employee } from '@/types/employee';
+import { SelectableEmployeeColumns, type Employee } from '@/types/employee';
 import { DataTableColumnHeader } from '@/ui/data-table-column-header';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/ui/select';
 import type { CellContext } from '@tanstack/react-table';
 import React from 'react';
 
 const HourlyRateCell: React.FC<CellContext<Employee, unknown>> = ({ row }) => {
-  if (!row.original.info.salary?.hourlyRate) return '';
+  const { defaultSelector, selectedSalaryId, setSelectedSalaryId } =
+    useSalary();
 
-  const value = getMoneyFromDecimals(row.original.info.salary.hourlyRate);
+  const disabled = defaultSelector !== SelectableEmployeeColumns.HOURLY_RATE;
 
-  return value;
+  React.useEffect(() => {
+    if (!selectedSalaryId && !disabled) {
+      setSelectedSalaryId(row.original.info.salaries?.[0]?.id.toString());
+    }
+  }, [selectedSalaryId, row.original.info.salaries, disabled]);
+
+  if (selectedSalaryId && disabled) {
+    const hourlyRate = row.original.info.salaries?.find(
+      (salary) => salary.id === Number(selectedSalaryId),
+    )?.hourlyRate;
+    return hourlyRate ? getMoneyFromDecimals(hourlyRate) : '';
+  }
+
+  if (!row.original.info.salaries || row.original.info.salaries.length === 0)
+    return '';
+
+  if (row.original.info.salaries.length === 1) {
+    if (!row.original.info.salaries[0]?.hourlyRate) return '';
+    if (!disabled)
+      setSelectedSalaryId(row.original.info.salaries[0]!.id.toString());
+    return getMoneyFromDecimals(row.original.info.salaries[0].hourlyRate);
+  }
+
+  return (
+    <Select
+      disabled={disabled}
+      value={selectedSalaryId}
+      onValueChange={setSelectedSalaryId}
+    >
+      <SelectTrigger>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {row.original.info.salaries.map((salary) => {
+          if (!salary.hourlyRate) return null;
+          return (
+            <SelectItem key={salary.id} value={salary.id.toString()}>
+              {getMoneyFromDecimals(salary.hourlyRate)}
+            </SelectItem>
+          );
+        })}
+      </SelectContent>
+    </Select>
+  );
 };
 
 export const hourlyRateColumn: ColumnDef<Employee> = {
   id: 'hourlyRate',
-  accessorKey: 'info.salary.hourlyRate',
+  accessorKey: 'info.salaries',
   header: ({ column }) => (
     <DataTableColumnHeader column={column} title={'Hourly Rate'} />
   ),

--- a/src/components/employees-table/columns/additional-fields/salary.tsx
+++ b/src/components/employees-table/columns/additional-fields/salary.tsx
@@ -1,23 +1,68 @@
+import { useSalary } from '@/context/table/columns/salaries/salary-context';
 import { getMoneyFromDecimals } from '@/lib/utils';
 import type { ColumnDef } from '@/types/components/data-table';
-import type { Employee } from '@/types/employee';
+import { SelectableEmployeeColumns, type Employee } from '@/types/employee';
 import { DataTableColumnHeader } from '@/ui/data-table-column-header';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/ui/select';
 import type { CellContext } from '@tanstack/react-table';
 import React from 'react';
 
 const SalaryColumnCell: React.FC<CellContext<Employee, unknown>> = ({
   row,
 }) => {
-  if (!row.original.info.salary?.value) return '';
+  const { defaultSelector, selectedSalaryId, setSelectedSalaryId } =
+    useSalary();
 
-  const value = getMoneyFromDecimals(row.original.info.salary.value);
+  const disabled = defaultSelector !== SelectableEmployeeColumns.SALARY;
 
-  return value;
+  React.useEffect(() => {
+    if (!selectedSalaryId && !disabled) {
+      setSelectedSalaryId(row.original.info.salaries?.[0]?.id.toString());
+    }
+  }, [selectedSalaryId, row.original.info.salaries, disabled]);
+
+  if (!row.original.info.salaries || row.original.info.salaries.length === 0)
+    return '';
+
+  if (row.original.info.salaries.length === 1) {
+    if (!row.original.info.salaries[0]?.value) return '';
+    if (!disabled)
+      setSelectedSalaryId(row.original.info.salaries[0]!.id.toString());
+    return getMoneyFromDecimals(row.original.info.salaries[0].value);
+  }
+
+  return (
+    <Select
+      disabled={disabled}
+      value={selectedSalaryId ?? row.original.info.salaries?.[0]?.id.toString()}
+      onValueChange={setSelectedSalaryId}
+    >
+      <SelectTrigger>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {row.original.info.salaries.map((salary) => {
+          if (!salary.value) return null;
+          return (
+            <SelectItem key={salary.id} value={salary.id.toString()}>
+              {getMoneyFromDecimals(salary.value)}
+            </SelectItem>
+          );
+        })}
+      </SelectContent>
+    </Select>
+  );
 };
 
 export const salaryColumn: ColumnDef<Employee> = {
   id: 'salary',
-  accessorKey: 'info.salary.value',
+  accessorKey: 'info.salaries',
   header: ({ column }) => (
     <DataTableColumnHeader column={column} title={'Salary'} />
   ),

--- a/src/components/employees-table/columns/core.tsx
+++ b/src/components/employees-table/columns/core.tsx
@@ -2,6 +2,13 @@ import type { ColumnDef } from '@/types/components/data-table';
 import type { Employee } from '@/types/employee';
 import { DataTableColumnHeader } from '@/ui/data-table-column-header';
 import ClipboardButton from '@/ui/extended/table/columns/copy';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/ui/select';
 import type { CellContext } from '@tanstack/react-table';
 import React from 'react';
 
@@ -19,7 +26,7 @@ export const fullNameColumn: ColumnDef<Employee> = {
 };
 
 const EmailColum: React.FC<CellContext<Employee, unknown>> = ({ row }) => {
-  const value = row.original.info.email;
+  const value = row.original.info.emails?.[0];
 
   if (!value) return null;
 
@@ -31,10 +38,34 @@ const EmailColum: React.FC<CellContext<Employee, unknown>> = ({ row }) => {
 
   const id = `dropdown-menu-${row.id}`;
 
+  if (row.original.info.emails?.length === 1) {
+    return (
+      <ClipboardButton id={id} data-email-value={value} getValue={getValue}>
+        {value}
+      </ClipboardButton>
+    );
+  }
+
   return (
-    <ClipboardButton id={id} data-email-value={value} getValue={getValue}>
-      {value}
-    </ClipboardButton>
+    <Select defaultValue={value}>
+      <div className='sc-flex sc-items-center sc-justify-between sc-gap-2'>
+        <ClipboardButton id={id} data-email-value={value} getValue={getValue}>
+          <SelectValue />
+        </ClipboardButton>
+        <SelectTrigger className='sc-group sc-relative sc-flex sc-w-fit sc-flex-col sc-items-center sc-justify-center sc-border-none sc-p-0'>
+          <div className='sc-absolute sc-translate-y-0 sc-text-xs sc-text-muted-foreground sc-opacity-0 sc-transition-all group-hover:-sc-translate-y-3 group-hover:sc-opacity-100'>
+            {row.original.info.emails?.length}
+          </div>
+        </SelectTrigger>
+      </div>
+      <SelectContent>
+        {row.original.info.emails?.map((email) => (
+          <SelectItem key={email} value={email}>
+            {email}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
   );
 };
 

--- a/src/components/employees-table/consts.ts
+++ b/src/components/employees-table/consts.ts
@@ -1,6 +1,6 @@
 import { nextPaymentDateColumn } from './columns/additional-fields/calendar/next-payment-date';
 import { payCycleColumn } from './columns/additional-fields/calendar/paycycle';
-import { startEmployementDateColumn } from './columns/additional-fields/calendar/start-employment-date';
+import { startEmploymentDateColumn } from './columns/additional-fields/calendar/start-employment-date';
 import { hourlyRateColumn } from './columns/additional-fields/hourly-rate';
 import { salaryColumn } from './columns/additional-fields/salary';
 import { type EmployeesTableAllowedColumnsMap } from './types';
@@ -11,7 +11,7 @@ export const EMPLOYEES_TABLE_ALLOWED_COLUMNS_MAP: EmployeesTableAllowedColumnsMa
     [SelectableEmployeeColumns.SALARY]: salaryColumn,
     [SelectableEmployeeColumns.HOURLY_RATE]: hourlyRateColumn,
     [SelectableEmployeeColumns.NEXT_PAYMENT_DATE]: nextPaymentDateColumn,
-    [SelectableEmployeeColumns.START_EMPLOYEMENT_DATE]:
-      startEmployementDateColumn,
+    [SelectableEmployeeColumns.START_EMPLOYMENT_DATE]:
+      startEmploymentDateColumn,
     [SelectableEmployeeColumns.PAYCYCLE]: payCycleColumn,
   };

--- a/src/components/employees-table/index.tsx
+++ b/src/components/employees-table/index.tsx
@@ -1,8 +1,10 @@
 import { useSubiConnectContext } from '@/context/subi-connect';
+import { CalendarProvider } from '@/context/table/columns/calendars/calendar-context';
+import { SalaryProvider } from '@/context/table/columns/salaries/salary-context';
 import { listAllEmployees } from '@/services/api/employee/actions';
 import { listAllOrganisations } from '@/services/api/payroll/actions';
 import type { ColumnDef, ListOptions } from '@/types/components/data-table';
-import type { Employee, SelectableEmployeeColumns } from '@/types/employee';
+import { SelectableEmployeeColumns, type Employee } from '@/types/employee';
 import type { DataTableToolbarFilterOptions } from '@/ui/data-table-toolbar';
 import GenericTable from '@/ui/extended/table/generic-table';
 import React from 'react';
@@ -31,12 +33,62 @@ const EmployeesTable: React.FC<{
     },
   ] satisfies DataTableToolbarFilterOptions<Employee, unknown>;
 
+  const SalaryContext = React.useCallback(
+    ({ children }: { children: React.ReactNode }) => {
+      const defaultSelector = enabledColumns.includes(
+        SelectableEmployeeColumns.SALARY,
+      )
+        ? SelectableEmployeeColumns.SALARY
+        : SelectableEmployeeColumns.HOURLY_RATE;
+      return (
+        <SalaryProvider defaultSelector={defaultSelector}>
+          {children}
+        </SalaryProvider>
+      );
+    },
+    [enabledColumns],
+  );
+
+  const CalendarContext = React.useCallback(
+    ({ children }: { children: React.ReactNode }) => {
+      return <CalendarProvider>{children}</CalendarProvider>;
+    },
+    [enabledColumns],
+  );
+
+  const rowContexts = React.useMemo(() => {
+    const contexts = [];
+    if (
+      enabledColumns.some(
+        (column) =>
+          column === SelectableEmployeeColumns.SALARY ||
+          column === SelectableEmployeeColumns.HOURLY_RATE,
+      )
+    ) {
+      contexts.push(SalaryContext);
+    }
+    if (
+      enabledColumns.some(
+        (column) =>
+          column === SelectableEmployeeColumns.PAYCYCLE ||
+          column === SelectableEmployeeColumns.NEXT_PAYMENT_DATE ||
+          column === SelectableEmployeeColumns.START_EMPLOYMENT_DATE,
+      )
+    ) {
+      contexts.push(CalendarContext);
+    }
+    return contexts;
+  }, [enabledColumns, SalaryContext, CalendarContext]);
+
   return (
     <GenericTable
       name='Employee'
       listAction={listAction}
       queryKeyFilters={[{ enabledColumns }]}
-      dataTableProps={{ toolbarProps: { filterOptions, hideSearchBar: false } }}
+      dataTableProps={{
+        toolbarProps: { filterOptions, hideSearchBar: false },
+        rowContexts: rowContexts,
+      }}
       columns={columns}
     />
   );

--- a/src/context/table/columns/calendars/calendar-context.tsx
+++ b/src/context/table/columns/calendars/calendar-context.tsx
@@ -1,0 +1,46 @@
+import { SelectableEmployeeColumns } from '@/types/employee';
+import React from 'react';
+
+type CalendarContextType = {
+  defaultSelector:
+    | SelectableEmployeeColumns.PAYCYCLE
+    | SelectableEmployeeColumns.NEXT_PAYMENT_DATE
+    | SelectableEmployeeColumns.START_EMPLOYMENT_DATE;
+  selectedCalendarId: string | undefined;
+  setSelectedCalendarId: (id: string | undefined) => void;
+};
+
+const CalendarContext = React.createContext<CalendarContextType | null>(null);
+
+export const CalendarProvider: React.FC<{
+  defaultSelector?: CalendarContextType['defaultSelector'];
+  children: React.ReactNode;
+}> = ({ defaultSelector = SelectableEmployeeColumns.PAYCYCLE, children }) => {
+  const [selectedCalendarId, setSelectedCalendarId] = React.useState<
+    string | undefined
+  >('');
+
+  const contextValue = React.useMemo(
+    () =>
+      ({
+        defaultSelector,
+        selectedCalendarId,
+        setSelectedCalendarId,
+      }) satisfies CalendarContextType,
+    [selectedCalendarId, setSelectedCalendarId, defaultSelector],
+  );
+
+  return (
+    <CalendarContext.Provider value={contextValue}>
+      {children}
+    </CalendarContext.Provider>
+  );
+};
+
+export const useCalendar = () => {
+  const context = React.useContext(CalendarContext);
+  if (!context) {
+    throw new Error('useCalendar must be used within a CalendarProvider');
+  }
+  return context;
+};

--- a/src/context/table/columns/salaries/salary-context.tsx
+++ b/src/context/table/columns/salaries/salary-context.tsx
@@ -1,0 +1,45 @@
+import { SelectableEmployeeColumns } from '@/types/employee';
+import React from 'react';
+
+type SalaryContextType = {
+  defaultSelector:
+    | SelectableEmployeeColumns.SALARY
+    | SelectableEmployeeColumns.HOURLY_RATE;
+  selectedSalaryId: string | undefined;
+  setSelectedSalaryId: (id: string | undefined) => void;
+};
+
+const SalaryContext = React.createContext<SalaryContextType | null>(null);
+
+export const SalaryProvider: React.FC<{
+  defaultSelector?: SalaryContextType['defaultSelector'];
+  children: React.ReactNode;
+}> = ({ defaultSelector = SelectableEmployeeColumns.SALARY, children }) => {
+  const [selectedSalaryId, setSelectedSalaryId] = React.useState<
+    string | undefined
+  >('');
+
+  const contextValue = React.useMemo(
+    () =>
+      ({
+        defaultSelector,
+        selectedSalaryId,
+        setSelectedSalaryId,
+      }) satisfies SalaryContextType,
+    [selectedSalaryId, setSelectedSalaryId, defaultSelector],
+  );
+
+  return (
+    <SalaryContext.Provider value={contextValue}>
+      {children}
+    </SalaryContext.Provider>
+  );
+};
+
+export const useSalary = () => {
+  const context = React.useContext(SalaryContext);
+  if (!context) {
+    throw new Error('useSalary must be used within a SalaryProvider');
+  }
+  return context;
+};

--- a/src/pages/employee-management/live.stories.tsx
+++ b/src/pages/employee-management/live.stories.tsx
@@ -30,7 +30,35 @@ export const HourlyRate: Story = {
   },
 };
 
-export const ALL: Story = {
+export const PayCycle: Story = {
+  args: {
+    enabledColumns: [SelectableEmployeeColumns.PAYCYCLE],
+  },
+};
+
+export const NextPaymentDate: Story = {
+  args: {
+    enabledColumns: [SelectableEmployeeColumns.NEXT_PAYMENT_DATE],
+  },
+};
+
+export const StartEmploymentDate: Story = {
+  args: {
+    enabledColumns: [SelectableEmployeeColumns.START_EMPLOYMENT_DATE],
+  },
+};
+
+export const AllCalendars: Story = {
+  args: {
+    enabledColumns: [
+      SelectableEmployeeColumns.PAYCYCLE,
+      SelectableEmployeeColumns.NEXT_PAYMENT_DATE,
+      SelectableEmployeeColumns.START_EMPLOYMENT_DATE,
+    ],
+  },
+};
+
+export const AllSalaries: Story = {
   args: {
     enabledColumns: [
       SelectableEmployeeColumns.SALARY,

--- a/src/services/api/employee/types.ts
+++ b/src/services/api/employee/types.ts
@@ -6,8 +6,8 @@ export type GetEmployeesResponse = Employee[];
 
 export type EmployeeFilterFields = Pick<
   Employee['info'],
-  'firstName' | 'lastName' | 'tfn' | 'email'
-> & { payrollCompanyOrganisationId: string | number };
+  'firstName' | 'lastName' | 'tfn'
+> & { payrollCompanyOrganisationId: string | number; email: string };
 export type ListAllEmployeesOptions = ListOptions &
   Partial<EmployeeFilterFields> & {
     params?: ListOptions['params'] &

--- a/src/types/employee.ts
+++ b/src/types/employee.ts
@@ -15,60 +15,84 @@ export enum EmployeeCalendarType {
   QUARTERLY = 'QUARTERLY',
 }
 
-export interface EmployeeSalary {
+export type EmployeeSalary = {
+  /**
+   * The id of the salary.
+   */
+  id: number;
+
   /**
    * The decimals for the currency.
    */
   decimal: number | null;
+
   /**
    * The salary of the employee in the currency.
    * E.g., value = 5000000; decimal = 2 => $50,000.00
    */
   value?: number | null;
+
   /**
    * The calculated hourly rate of the employee based on their yearly salary.
    */
   hourlyRate?: number | null;
-}
+};
 
-export interface EmployeeCalendar {
-  paycycle?: EmployeeCalendarType;
-  nextPaymentDate?: string;
-  startEmploymentDate?: string;
-}
+export type EmployeeCalendar = {
+  /**
+   * The id of the calendar.
+   */
+  id: number;
 
-export interface EmployeeSync {
+  /**
+   * The type of pay cycle for the employee.
+   */
+  paycycle: EmployeeCalendarType;
+
+  /**
+   * The next payment date for the employee.
+   */
+  nextPaymentDate: string;
+
+  /**
+   * The start employment date for the employee.
+   */
+  startEmploymentDate: string;
+};
+
+export type EmployeeSync = {
   lastSyncAt: Date;
   syncedAt?: Date;
   status: SyncStatus;
-}
+};
 
-export interface EmployeeInfo {
+export type EmployeeInfo = {
   firstName: string;
   lastName: string;
   dateOfBirth?: Date;
   tfn?: string;
-  email?: string;
-  salary?: EmployeeSalary;
-  calendar?: EmployeeCalendar;
-}
-export interface EmployeePayrollOrganisation {
+  emails?: string[];
+  salaries?: EmployeeSalary[];
+  calendars?: EmployeeCalendar[];
+};
+
+export type EmployeePayrollOrganisation = {
   id: number;
   name: string;
   referenceId: string;
-}
+};
 
-export interface EmployeeMetadata {
+export type EmployeeMetadata = {
   sync: EmployeeSync;
   createdAt: Date;
   updatedAt?: Date;
-}
+};
 
-export interface EmployeePayroll {
+export type EmployeePayroll = {
   name: Payroll;
   referenceEmployeeId: string;
   organisation: EmployeePayrollOrganisation;
-}
+};
 
 export type Employee = {
   id: number;
@@ -82,6 +106,6 @@ export enum SelectableEmployeeColumns {
   SALARY = 'salary',
   HOURLY_RATE = 'hourlyRate',
   NEXT_PAYMENT_DATE = 'nextPaymentDate',
-  START_EMPLOYEMENT_DATE = 'startEmploymentDate',
+  START_EMPLOYMENT_DATE = 'startEmploymentDate',
   PAYCYCLE = 'paycycle',
 }

--- a/src/ui/data-table.tsx
+++ b/src/ui/data-table.tsx
@@ -30,11 +30,13 @@ import React from 'react';
 export type DataTableProps<TData, TValue> = {
   columns: ColumnDef<TData, TValue>[];
   toolbarProps?: TypedOmit<DataTableToolbarProps<TData, TValue>, 'table'>;
+  rowContexts?: React.FC<{ children: React.ReactNode }>[];
 };
 
 export function DataTable<TData, TValue>({
   columns,
   toolbarProps,
+  rowContexts = [React.Fragment],
 }: Readonly<DataTableProps<TData, TValue>>) {
   const [sorting, setSorting] = React.useState<SortingState>([]);
   const {
@@ -99,21 +101,25 @@ export function DataTable<TData, TValue>({
           </TableHeader>
           <TableBody>
             {table.getRowModel().rows?.length ? (
-              table.getRowModel().rows.map((row) => (
-                <TableRow
-                  key={row.id}
-                  data-state={row.getIsSelected() && 'selected'}
-                >
-                  {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id}>
-                      {flexRender(
-                        cell.column.columnDef.cell,
-                        cell.getContext(),
-                      )}
-                    </TableCell>
-                  ))}
-                </TableRow>
-              ))
+              table.getRowModel().rows.map((row) =>
+                rowContexts?.map((Context) => (
+                  <Context key={row.id}>
+                    <TableRow
+                      key={row.id}
+                      data-state={row.getIsSelected() && 'selected'}
+                    >
+                      {row.getVisibleCells().map((cell) => (
+                        <TableCell key={cell.id}>
+                          {flexRender(
+                            cell.column.columnDef.cell,
+                            cell.getContext(),
+                          )}
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  </Context>
+                )),
+              )
             ) : (
               <TableRow>
                 <TableCell


### PR DESCRIPTION
#### What is the purpose of this pull request?

This pull request updates the employee table component to support multiple salaries and calendars per employee. It introduces new context providers for managing salary and calendar selections, and modifies the table columns to display selectable options when an employee has multiple salaries or calendars.

#### What problem is this solving?

The existing implementation only supported a single salary and calendar per employee. This change allows for more flexible employee data representation, accommodating scenarios where employees may have multiple salaries or calendars associated with their profile.

#### Types of changes

- [x] Feat: (new functionality)
- [ ] Bug fix: ([#ref number] non-breaking change which fixes an issue)
- [ ] Chore: (improvements that will not reflect in production behaviour)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires change to documentation, which has been updated accordingly.