### PR TITLE
fix: Employee table with no added columns

### DIFF
--- a/.changeset/light-pants-applaud.md
+++ b/.changeset/light-pants-applaud.md
@@ -1,0 +1,8 @@
+---
+'@subifinancial/subi-connect': patch
+---
+
+## Changes
+
+- Modified the `EmployeesTable` component to return `undefined` when the `contexts` array is empty, instead of returning an empty array. This ensures that when no columns are added, an empty context array isn't provided, so rows show correctly.
+

--- a/src/components/employees-table/index.tsx
+++ b/src/components/employees-table/index.tsx
@@ -77,7 +77,7 @@ const EmployeesTable: React.FC<{
     ) {
       contexts.push(CalendarContext);
     }
-    return contexts;
+    return contexts.length > 0 ? contexts : undefined;
   }, [enabledColumns, SalaryContext, CalendarContext]);
 
   return (


### PR DESCRIPTION
#### What is the purpose of this pull request?

This change modifies the `EmployeesTable` component to return `undefined` when the `contexts` array is empty, instead of returning an empty array.

#### What problem is this solving?

The modification ensures that when no contexts are enabled, the component returns `undefined` rather than an empty array. This can potentially optimize performance and improve consistency in how the absence of contexts is represented.

#### Types of changes

- [x] Chore: (improvements that will not reflect in production behaviour)