### PR TITLE
fix: reinitiate when company context changes

### DIFF
--- a/.changeset/clean-rice-think.md
+++ b/.changeset/clean-rice-think.md
@@ -1,0 +1,7 @@
+---
+'@subifinancial/subi-connect': patch
+---
+
+This change updates the `SubiConnectProvider` and `useSubiConnectQuery` components to improve dependency management and query execution control. The changes address potential issues with stale closures and ensure that queries are only executed when the SubiConnect context is properly initialised.
+
+- **Query Execution Control**: The `useSubiConnectQuery` hook now checks the `initialised` state of the SubiConnect context before executing a query. This ensures that queries are not executed prematurely.

--- a/src/context/subi-connect.tsx
+++ b/src/context/subi-connect.tsx
@@ -78,7 +78,7 @@ export const SubiConnectProvider = <TCompanyContext extends string>({
   const queryClient = useQueryClient();
   const [isLoading, setIsLoading] = React.useState<boolean>(true);
   const [initialised, setInitialised] = React.useState<boolean>(false);
-  const logger = React.useMemo(() => new Logger(), []);
+  const logger = React.useMemo(() => new Logger(), [companyContext]);
   const connectionService = React.useMemo(
     () =>
       new ConnectionService({ connectionFn, context: companyContext, logger }),
@@ -124,7 +124,7 @@ export const SubiConnectProvider = <TCompanyContext extends string>({
     };
 
     initConnection();
-  }, [connectionFn, options, connectionService]);
+  }, [connectionFn, companyContext, options, connectionService]);
 
   /**
    * Clear the access token from local storage and the connection service.

--- a/src/hooks/use-subi-connect-query.ts
+++ b/src/hooks/use-subi-connect-query.ts
@@ -13,8 +13,12 @@ export function useSubiConnectQuery<
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 >(options: UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>) {
-  useSubiConnectContext();
-  return useQuery(options);
+  const { initialised } = useSubiConnectContext();
+  const { enabled, ...queryOptions } = options;
+  return useQuery({
+    ...queryOptions,
+    enabled: initialised && enabled,
+  });
 }
 
 export function useSubiConnectMutation<


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR updates the `SubiConnectProvider` and `useSubiConnectQuery` components to improve dependency management and query execution control.

#### What problem is this solving?

The changes address potential issues with stale closures and ensure that queries are only executed when the SubiConnect context is properly initialized.

#### Types of changes

- [x] Bug fix: (non-breaking change which fixes an issue)
- [x] Chore: (improvements that will not reflect in production behaviour)

In the `SubiConnectProvider`:
- Added `companyContext` to the dependency array of the `logger` useMemo hook.
- Added `companyContext` to the dependency array of the `useEffect` hook that initializes the connection.

In the `useSubiConnectQuery` hook:
- Modified the hook to only enable queries when the SubiConnect context is initialized.
- Destructured the `enabled` option from the query options to combine it with the `initialised` state from the context.

These changes ensure proper reactivity to context changes and prevent premature query execution.