### PR TITLE
feat: add updateAccessToken method and refactor error interceptor

### DIFF
--- a/.changeset/heavy-points-brush.md
+++ b/.changeset/heavy-points-brush.md
@@ -1,0 +1,6 @@
+---
+'@subifinancial/subi-connect': patch
+---
+
+Added a `updateAccessToken` method in `connection-service.ts` to update the access token in storage, and set the Authorization header with the new token—the error interceptor now uses this method to update the token.
+

--- a/src/services/axios/connection-service.ts
+++ b/src/services/axios/connection-service.ts
@@ -105,6 +105,13 @@ export class ConnectionService {
     return this;
   }
 
+  public updateAccessToken(token: string) {
+    this.setAccessToken(token);
+    this.httpClient.defaults.headers.common['Authorization'] =
+      `Bearer ${token}`;
+    return this;
+  }
+
   private hexEncodeContext(context: string) {
     return Array.from(context)
       .map((char) => char.charCodeAt(0).toString(16).padStart(2, '0'))

--- a/src/services/axios/interceptors/error.ts
+++ b/src/services/axios/interceptors/error.ts
@@ -67,10 +67,8 @@ const onErrorResponse =
           return Promise.reject(error);
         }
 
-        // Update the token in Axios defaults
-        connectionService.getHttpClient().defaults.headers.common[
-          'Authorization'
-        ] = `Bearer ${newToken}`;
+        // Update the token
+        connectionService.updateAccessToken(newToken);
         // Update the token on the original request
         originalRequest.headers['Authorization'] = `Bearer ${newToken}`;
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR introduces a new `updateAccessToken` method in the `ConnectionService` class. It also refactors the error interceptor to use this new method for updating the access token.

#### What problem is this solving?

The change improves the token update process by encapsulating the logic within the `ConnectionService`. This ensures consistency in how the access token is updated across the application and simplifies the error interceptor's code.

#### Types of changes

- [x] Feat: (new functionality)
- [ ] Bug fix: ([#ref number] non-breaking change which fixes an issue)
- [x] Chore: (improvements that will not reflect in production behaviour)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.