### PR TITLE
ci: add manual release trigger option

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,9 @@ jobs:
     name: 🚀 Release
     runs-on: ubuntu-latest
     if: >
-      github.event_name == 'workflow_dispatch' || (github.event_name ==
-      'pull_request' && github.event.pull_request.merged == true &&
+      (github.event.inputs.release == true && github.event_name ==
+      'workflow_dispatch') || (github.event_name == 'pull_request' &&
+      github.event.pull_request.merged == true &&
       github.event.pull_request.base.ref == 'main' &&
       github.event.pull_request.head.ref == 'changeset-release/main')
     outputs:


### PR DESCRIPTION
#### What is the purpose of this pull request?

This change modifies the release workflow to allow manual triggering of releases through workflow dispatch. It adds a condition to check if the `release` input is set to true when the workflow is manually dispatched.

#### What problem is this solving?

The current workflow only allows releases to be triggered automatically when a pull request from the changeset release branch is merged. This update provides more flexibility by enabling manual release initiation when needed.

#### Types of changes

- [x] Feat: (new functionality)
- [ ] Bug fix: ([#ref number] non-breaking change which fixes an issue)
- [ ] Chore: (improvements that will not reflect in production behaviour)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.