### PR TITLE
fix: remove unnecessary useEffect dependencies

### DIFF
--- a/.changeset/spotty-hats-own.md
+++ b/.changeset/spotty-hats-own.md
@@ -1,0 +1,7 @@
+---
+'@subifinancial/subi-connect': patch
+---
+
+Remove unnecessary dependencies from `useEffect` dependency array in `SubiConnectProvider`.
+
+

--- a/src/context/subi-connect.tsx
+++ b/src/context/subi-connect.tsx
@@ -124,7 +124,7 @@ export const SubiConnectProvider = <TCompanyContext extends string>({
     };
 
     initConnection();
-  }, [connectionFn, companyContext, options, connectionService]);
+  }, [options, connectionService]);
 
   /**
    * Clear the access token from local storage and the connection service.


### PR DESCRIPTION
#### What is the purpose of this pull request?

Removes unnecessary dependencies (`connectionFn` and `companyContext`) from the `useEffect` dependency array in the `SubiConnectProvider` component.

#### What problem is this solving?

The dependency array included variables that weren't actually being used within the effect, which could lead to unnecessary re-renders and potential performance issues.

#### Types of changes

- [ ] Feat: (new functionality)
- [x] Bug fix: (non-breaking change which fixes an issue)
- [ ] Chore: (improvements that will not reflect in production behaviour)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.