### PR TITLE
refactor: optimize SubiConnect provider initialization

### DIFF
--- a/.changeset/afraid-walls-double.md
+++ b/.changeset/afraid-walls-double.md
@@ -1,0 +1,9 @@
+---
+'@subifinancial/subi-connect': patch
+---
+
+Optimise `SubiConnect` provider initialisation and cleanup:
+- Set `initialised` state immediately when loading starts
+- Remove redundant `initialised` check and set
+- Memoise cleanup function with `useCallback` to prevent unnecessary rerenders
+- Update dependency array in value memo to include cleanup function 

--- a/src/context/subi-connect.tsx
+++ b/src/context/subi-connect.tsx
@@ -91,6 +91,7 @@ export const SubiConnectProvider = <TCompanyContext extends string>({
    */
   React.useEffect(() => {
     setIsLoading(true);
+    setInitialised(true);
 
     /**
      * Handle options passed to the `SubiConnectProvider`.
@@ -120,7 +121,7 @@ export const SubiConnectProvider = <TCompanyContext extends string>({
       }
 
       setIsLoading(false);
-      if (!initialised) setInitialised(true);
+      setInitialised(true);
     };
 
     initConnection();
@@ -129,24 +130,27 @@ export const SubiConnectProvider = <TCompanyContext extends string>({
   /**
    * Clear the access token from local storage and the connection service.
    */
-  const cleanup = (props: SubiConnectCleanupProps = {}) => {
-    connectionService.reset({
-      keepAccessToken: props.keepData,
-    });
-
-    if (!props.keepData) {
-      const queryKey = [
-        SUBI_CONNECT_QUERY_KEY,
-        ...(props.cleanupAllContexts
-          ? []
-          : [{ context: connectionService.getContext() }]),
-      ];
-
-      queryClient.removeQueries({
-        queryKey: queryKey,
+  const cleanup = React.useCallback(
+    (props: SubiConnectCleanupProps = {}) => {
+      connectionService.reset({
+        keepAccessToken: props.keepData,
       });
-    }
-  };
+
+      if (!props.keepData) {
+        const queryKey = [
+          SUBI_CONNECT_QUERY_KEY,
+          ...(props.cleanupAllContexts
+            ? []
+            : [{ context: connectionService.getContext() }]),
+        ];
+
+        queryClient.removeQueries({
+          queryKey: queryKey,
+        });
+      }
+    },
+    [connectionService, queryClient],
+  );
 
   const value = React.useMemo(() => {
     return {
@@ -155,7 +159,7 @@ export const SubiConnectProvider = <TCompanyContext extends string>({
       cleanup,
       connectionService,
     } satisfies SubiConnectContext;
-  }, [isLoading, initialised, connectionService]);
+  }, [isLoading, initialised, cleanup, connectionService]);
 
   return (
     <SubiConnectContext.Provider value={value}>


### PR DESCRIPTION
#### What is the purpose of this pull request?

Enhances the initialization process of the `SubiConnect` provider by optimizing state management and preventing unnecessary rerenders. The `cleanup` function is now memoized using `useCallback`, and state updates during initialization have been streamlined.

#### What problem is this solving?

Addresses performance inefficiencies in the provider's initialization flow by:
- Setting the `initialised` state immediately when loading begins
- Eliminating redundant state checks and updates
- Preventing unnecessary rerenders through proper function memoization
- Ensuring proper dependency tracking in the value memo

#### Types of changes

- [ ] Feat: (new functionality)
- [x] Bug fix: (non-breaking change which fixes an issue)
- [ ] Chore: (improvements that will not reflect in production behaviour)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.