### PR TITLE
refactor: optimize SubiConnect initialization flow

### DIFF
--- a/.changeset/shy-actors-peel.md
+++ b/.changeset/shy-actors-peel.md
@@ -1,0 +1,14 @@
+---
+'@subifinancial/subi-connect': patch
+---
+
+Improved initialisation and configuration handling:
+
+- Changed `initialised` state to use `useRef` instead of `useState` for better state management
+- Moved provider options handling into `ConnectionService` constructor
+- Simplified provider options handling by passing `httpClient` directly instead of `ConnectionService`
+- Fixed dependency array in `SubiConnectProvider`'s `useMemo`
+- Removed redundant initialisation code and improved initialisation flow
+- Added `providerOptions` to `ConnectionService` constructor parameters
+
+

--- a/src/lib/handle-provider-options.tsx
+++ b/src/lib/handle-provider-options.tsx
@@ -4,11 +4,11 @@ import {
   type SubiConnectOptions,
 } from '../types/main';
 import { SUBI_CONNECT_SANDBOX_PUBLIC_BASE_URL } from '@/envs';
-import type { ConnectionService } from '@/services/axios/connection-service';
 import { Logger } from '@/services/logger';
+import type { AxiosInstance } from 'axios';
 
 type InternalInitialisationOptions = {
-  connectionService: ConnectionService;
+  httpClient: AxiosInstance;
   logger: Logger;
 };
 
@@ -19,10 +19,10 @@ const handleDebugOptions = ({
   NODE_ENV,
   baseURL,
   disabledLogging = false,
-  connectionService,
+  httpClient,
   logger,
 }: SubiConnectDebugOptions & InternalInitialisationOptions) => {
-  if (baseURL) connectionService.getHttpClient().defaults.baseURL = baseURL;
+  if (baseURL) httpClient.defaults.baseURL = baseURL;
   logger.initialise({
     env: NODE_ENV,
     enabled: !disabledLogging,
@@ -35,15 +35,14 @@ const handleDebugOptions = ({
 export const handleProviderOptions = ({
   debug,
   environment,
-  connectionService,
+  httpClient,
   logger,
 }: SubiConnectOptions & InternalInitialisationOptions) => {
   if (environment && environment === SubiConnectEnvironment.SANDBOX) {
-    connectionService.getHttpClient().defaults.baseURL =
-      SUBI_CONNECT_SANDBOX_PUBLIC_BASE_URL;
+    httpClient.defaults.baseURL = SUBI_CONNECT_SANDBOX_PUBLIC_BASE_URL;
   }
 
   if (debug) {
-    handleDebugOptions({ ...debug, connectionService, logger });
+    handleDebugOptions({ ...debug, httpClient, logger });
   }
 };

--- a/src/services/axios/connection-service.ts
+++ b/src/services/axios/connection-service.ts
@@ -1,8 +1,9 @@
 import { httpClient } from '.';
-import type { ILogger } from '../logger/ILogger';
+import type { Logger } from '../logger';
 import type { ConnectionServiceResetOptions } from './types';
 import { ACCESS_TOKEN_NAME } from '@/constants';
-import type { SubiConnectConnectionFn } from '@/types/main';
+import { handleProviderOptions } from '@/lib/handle-provider-options';
+import type { SubiConnectConnectionFn, SubiConnectOptions } from '@/types/main';
 import type { AxiosInstance } from 'axios';
 
 const DEFAULT_CONTEXT = '';
@@ -22,14 +23,22 @@ export class ConnectionService {
     connectionFn,
     context,
     logger,
+    providerOptions,
   }: {
     connectionFn: SubiConnectConnectionFn | null;
     context: string;
-    logger: ILogger;
+    logger: Logger;
+    providerOptions?: SubiConnectOptions;
   }) {
     this.setConnectionFn(connectionFn);
     this.setContext(context);
     this.httpClient = httpClient({ connectionService: this, logger });
+
+    handleProviderOptions({
+      httpClient: this.httpClient,
+      logger,
+      ...providerOptions,
+    });
   }
 
   public setConnectionFn(fn: SubiConnectConnectionFn | null) {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Enhances the initialization process in SubiConnect by refactoring state management and provider configuration handling. The changes move provider options handling into the ConnectionService constructor and improve state tracking using useRef instead of useState.

#### What problem is this solving?

Addresses inefficiencies in the initialization flow and state management by:
- Preventing unnecessary re-renders with useRef for initialization state
- Streamlining provider options configuration
- Improving the separation of concerns by moving provider options handling to ConnectionService
- Fixing dependency array issues in SubiConnectProvider's useMemo hook

#### Types of changes

- [ ] Feat: (new functionality)
- [x] Bug fix: (non-breaking change which fixes an issue)
- [x] Chore: (improvements that will not reflect in production behaviour)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.