### PR TITLE
fix: add connectionService to hook dependency arrays

### DIFF
--- a/.changeset/rotten-donkeys-cross.md
+++ b/.changeset/rotten-donkeys-cross.md
@@ -1,0 +1,12 @@
+---
+'@subifinancial/subi-connect': patch
+---
+
+
+Added `connectionService` context to dependency arrays in React hooks to ensure proper cache invalidation when the connection context changes. Updated hooks include:
+- `useAccountPayrollSystem`
+- `useEmployees`
+- `useOrganisations`
+- `useAllOrganisations`
+- `useOrganisation`
+- `usePayrollSystems`

--- a/src/hooks/use-account-payroll.tsx
+++ b/src/hooks/use-account-payroll.tsx
@@ -29,7 +29,7 @@ export const useAccountPayrollSystem = (
       'detail',
       payroll,
     ],
-    [payroll],
+    [payroll, connectionService.getContext()],
   );
 
   const queryFn = React.useCallback(

--- a/src/hooks/use-employees.tsx
+++ b/src/hooks/use-employees.tsx
@@ -46,7 +46,7 @@ export const useEmployees = (options?: UseEmployeesOptions) => {
         filters: params,
       },
     ],
-    [params],
+    [params, connectionService.getContext()],
   );
 
   const queryFn = React.useCallback(

--- a/src/hooks/use-organisations.tsx
+++ b/src/hooks/use-organisations.tsx
@@ -60,7 +60,7 @@ export const useOrganisations = (
         filters: params,
       },
     ],
-    [accountPayrollId, params],
+    [accountPayrollId, params, connectionService.getContext()],
   );
 
   const queryFn = React.useCallback(
@@ -114,7 +114,7 @@ export const useAllOrganisations = (options?: UseAllOrganisationsOptions) => {
         filters: params,
       },
     ],
-    [params],
+    [params, connectionService.getContext()],
   );
 
   const queryFn = React.useCallback(
@@ -178,7 +178,7 @@ export const useOrganisation = (
       'detail',
       organisationId,
     ],
-    [organisationId],
+    [organisationId, connectionService.getContext()],
   );
 
   const queryFn = React.useCallback(

--- a/src/hooks/use-payroll-systems.tsx
+++ b/src/hooks/use-payroll-systems.tsx
@@ -47,7 +47,7 @@ export const usePayrollSystems = (options?: UsePayrollSystemsOptions) => {
         filters: params,
       },
     ],
-    [params],
+    [params, connectionService.getContext()],
   );
 
   const queryFn = React.useCallback(


### PR DESCRIPTION
#### What is the purpose of this pull request?

Added `connectionService` context to dependency arrays in React hooks to ensure proper cache invalidation when the connection context changes. This update affects `useAccountPayrollSystem`, `useEmployees`, `useOrganisations`, `useAllOrganisations`, `useOrganisation`, and `usePayrollSystems` hooks.

#### What problem is this solving?

The hooks were not properly invalidating their caches when the connection context changed, potentially leading to stale data being displayed. By adding the connection context to the dependency arrays, we ensure that the cached data is refreshed whenever the connection state changes.

#### Types of changes

- [ ] Feat: (new functionality)
- [x] Bug fix: (non-breaking change which fixes an issue)
- [ ] Chore: (improvements that will not reflect in production behaviour)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.