### PR TITLE
refactor: update query filters and payroll system ID structure

### DIFF
--- a/.changeset/strange-eyes-behave.md
+++ b/.changeset/strange-eyes-behave.md
@@ -1,0 +1,54 @@
+---
+'@subifinancial/subi-connect': major
+---
+
+### Breaking Changes
+
+#### Query Key Filters Structure Change
+- Changed `queryKeyFilters` type from array to object structure across all table components
+- Updated `DataTableProviderProps` interface to use `Record<string, unknown>` instead of `QueryKey`
+- This affects all components using `GenericTable` and `DataTableProvider`
+
+#### Payroll Integration Parameter Changes
+- Changed `accountPayrollId` to `payrollSystemId` throughout the codebase
+- This affects:
+  - `PayrollIntegrationManagementTable` component
+  - `useOrganisations` hook
+  - `listOrganisationsFromPayroll` action
+  - `getOrganisationsFromPayrollURL` path helper
+
+### Migration Guide
+
+#### Query Key Filters
+Before:
+```tsx
+queryKeyFilters={[{ enabledColumns }]}
+```
+
+After:
+```tsx
+queryKeyFilters={{ enabledColumns }}
+```
+
+#### Payroll System ID
+Before:
+```tsx
+const App = () => {
+    const { data: accountPayroll } = useAccountPayrollSystem(payroll);
+    const { data: organisations } = useOrganisations(accountPayroll.id);
+
+    return <PayrollIntegrationManagementTable accountPayrollId={accountPayroll.id} />
+}
+```
+
+After:
+```tsx
+const App = () => {
+    const { data: accountPayroll } = useAccountPayrollSystem(payroll);
+    const { data: organisations } = useOrganisations(accountPayroll.payrollId);
+    
+    return <PayrollIntegrationManagementTable payrollSystemId={accountPayroll.payrollId} />
+}
+```
+
+

--- a/src/components/employees-table/index.tsx
+++ b/src/components/employees-table/index.tsx
@@ -84,7 +84,7 @@ const EmployeesTable: React.FC<{
     <GenericTable
       name='Employee'
       listAction={listAction}
-      queryKeyFilters={[{ enabledColumns }]}
+      queryKeyFilters={{ enabledColumns }}
       dataTableProps={{
         toolbarProps: { filterOptions, hideSearchBar: false },
         rowContexts: rowContexts,

--- a/src/components/payroll-integration-management-table/index.tsx
+++ b/src/components/payroll-integration-management-table/index.tsx
@@ -6,17 +6,14 @@ import GenericTable from '@/ui/extended/table/generic-table';
 import React from 'react';
 
 const PayrollIntegrationManagementTable: React.FC<{
-  accountPayrollId: number;
-}> = ({ accountPayrollId }) => {
+  payrollSystemId: number;
+}> = ({ payrollSystemId }) => {
   const { connectionService } = useSubiConnectContext();
 
   const listAction = React.useCallback(
     (options: ListOptions | undefined) =>
-      listOrganisationsFromPayroll(connectionService)(
-        accountPayrollId,
-        options,
-      ),
-    [accountPayrollId, connectionService],
+      listOrganisationsFromPayroll(connectionService)(payrollSystemId, options),
+    [payrollSystemId, connectionService],
   );
 
   return (
@@ -24,7 +21,7 @@ const PayrollIntegrationManagementTable: React.FC<{
       name={'Organisation'}
       listAction={listAction}
       columns={columns}
-      queryKeyFilters={[{ accountPayrollId }]}
+      queryKeyFilters={{ payrollSystemId }}
     />
   );
 };

--- a/src/context/table/table-context.tsx
+++ b/src/context/table/table-context.tsx
@@ -88,11 +88,11 @@ export const useDataTableContext = <TData,>(): IDataTableContext<TData> => {
   return context;
 };
 
-interface DataTableProviderProps<TData> {
+export type DataTableProviderProps<TData> = {
   children: React.ReactNode;
   name: string;
   listAction: ListRequest<never, TData>;
-  queryKeyFilters?: QueryKey;
+  queryKeyFilters?: Record<string, unknown>;
   queryOptions?: Omit<
     UseQueryOptions<
       PaginationResponse<TData>,
@@ -102,13 +102,13 @@ interface DataTableProviderProps<TData> {
     >,
     'initialData' | 'queryKey'
   >;
-}
+};
 
 export const DataTableProvider = <TData,>({
   children,
   name,
   listAction,
-  queryKeyFilters = [],
+  queryKeyFilters = {},
   queryOptions,
 }: DataTableProviderProps<TData>) => {
   const { getSearchParam, setSearchParam, getAllParams } = useSearchParams();

--- a/src/hooks/use-organisations.tsx
+++ b/src/hooks/use-organisations.tsx
@@ -36,7 +36,7 @@ type UseOrganisationsOptions = {
 };
 
 export const useOrganisations = (
-  accountPayrollId: number | undefined,
+  payrollSystemId: number | undefined,
   options?: UseOrganisationsOptions,
 ) => {
   const { connectionService } = useSubiConnectContext();
@@ -56,20 +56,20 @@ export const useOrganisations = (
       BASE_ORGANISATION_QUERY_KEY,
       'list',
       {
-        accountPayrollId,
+        payrollSystemId,
         filters: params,
       },
     ],
-    [accountPayrollId, params, connectionService.getContext()],
+    [payrollSystemId, params, connectionService.getContext()],
   );
 
   const queryFn = React.useCallback(
     () =>
-      listOrganisationsFromPayroll(connectionService)(accountPayrollId!, {
+      listOrganisationsFromPayroll(connectionService)(payrollSystemId!, {
         ...options?.listOptions,
         params: params,
       }),
-    [accountPayrollId, options?.listOptions, params, connectionService],
+    [payrollSystemId, options?.listOptions, params, connectionService],
   );
 
   const { enabled, ...restOfQueryOptions } = options?.queryOptions ?? {
@@ -79,7 +79,7 @@ export const useOrganisations = (
   return useSubiConnectQuery({
     queryKey: queryKey,
     queryFn: queryFn,
-    enabled: !!accountPayrollId && enabled,
+    enabled: !!payrollSystemId && enabled,
     ...restOfQueryOptions,
   });
 };

--- a/src/pages/payroll-integration-management/index.tsx
+++ b/src/pages/payroll-integration-management/index.tsx
@@ -174,7 +174,7 @@ const PayrollIntegrationManagementPage: React.FC<{
 
           <div className='sc-h-full sc-w-full'>
             <PayrollIntegrationManagementTable
-              accountPayrollId={accountPayroll.id}
+              payrollSystemId={accountPayroll.payrollId}
             />
           </div>
         </div>

--- a/src/services/api/payroll/actions.ts
+++ b/src/services/api/payroll/actions.ts
@@ -112,12 +112,12 @@ export const integrateManualPayroll = withConnectionService(
 export const listOrganisationsFromPayroll = withConnectionService(
   async (
     connectionService: ConnectionService,
-    accountPayrollId: number | string,
+    payrollSystemId: number | string,
     options?: ListOptions,
   ): Promise<PaginationResponse<Organisation>> => {
     const httpClient = connectionService.getHttpClient();
     const response = await httpClient.get<PaginationResponse<Organisation>>(
-      getOrganisationsFromPayrollURL(accountPayrollId),
+      getOrganisationsFromPayrollURL(payrollSystemId),
       options,
     );
     return response.data;

--- a/src/services/api/payroll/paths.ts
+++ b/src/services/api/payroll/paths.ts
@@ -27,9 +27,11 @@ export const getAccountPayrollURL = (payroll: Payroll) => {
   );
 };
 
-export const getOrganisationsFromPayrollURL = (payrollId: number | string) => {
+export const getOrganisationsFromPayrollURL = (
+  payrollSystemId: number | string,
+) => {
   return constructAPIURL(
-    `${PAYROLL_APPLICATIONS_URL}/${payrollId}/organisations`,
+    `${PAYROLL_APPLICATIONS_URL}/${payrollSystemId}/organisations`,
   );
 };
 

--- a/src/ui/extended/table/generic-table.tsx
+++ b/src/ui/extended/table/generic-table.tsx
@@ -1,32 +1,20 @@
 import { DataTablePaginationProvider } from '@/context/table/pagination-context';
 import { DataTableSearchProvider } from '@/context/table/search-context';
-import { DataTableProvider } from '@/context/table/table-context';
-import type {
-  ListRequest,
-  PaginationResponse,
-  BaseQueryData,
-  ColumnDef,
-} from '@/types/components/data-table';
+import {
+  DataTableProvider,
+  type DataTableProviderProps,
+} from '@/context/table/table-context';
+import type { BaseQueryData, ColumnDef } from '@/types/components/data-table';
 import type { TypedOmit } from '@/types/utils';
 import { DataTable, type DataTableProps } from '@/ui/data-table';
-import type { QueryKey, UseQueryOptions } from '@tanstack/react-query';
 import React from 'react';
 
-type GenericTableProps<TData, TValue> = {
-  name: string;
-  listAction: ListRequest<never, TData>;
-  queryOptions?: Omit<
-    UseQueryOptions<
-      PaginationResponse<TData>,
-      unknown,
-      PaginationResponse<TData>,
-      QueryKey
-    >,
-    'initialData' | 'queryKey'
-  >;
+type GenericTableProps<TData, TValue> = Pick<
+  DataTableProviderProps<TData>,
+  'name' | 'listAction' | 'queryOptions' | 'queryKeyFilters'
+> & {
   columns: ColumnDef<TData, TValue>[];
   dataTableProps?: TypedOmit<DataTableProps<TData, TValue>, 'columns'>;
-  queryKeyFilters?: QueryKey;
 };
 
 const GenericTable = <TData extends BaseQueryData, TValue>({


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR introduces two significant structural changes to improve consistency and clarity in the codebase:
1. Converts query key filters from array to object structure in table components
2. Renames `accountPayrollId` to `payrollSystemId` across payroll integration components

#### What problem is this solving?

1. The array structure for query key filters was less intuitive and made type checking more difficult. The new object structure provides better type safety and clearer data organization.
2. The parameter naming inconsistency between `accountPayrollId` and `payrollSystemId` was causing confusion. The standardization to `payrollSystemId` better reflects its actual purpose.

#### Types of changes

- [ ] Feat: (new functionality)
- [ ] Bug fix: (non-breaking change which fixes an issue)
- [ ] Chore: (improvements that will not reflect in production behaviour)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires change to documentation, which has been updated accordingly.